### PR TITLE
[ci] chore(tooling): add check signed commit (#154)

### DIFF
--- a/.github/workflows/integrations-check-signed-commit.yml
+++ b/.github/workflows/integrations-check-signed-commit.yml
@@ -1,0 +1,13 @@
+name: "[Integrations] Check Signed Commits in PR"
+on:
+  pull_request_target:
+    branches: [main, release/current]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  check-signed-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check signed commits in PR
+        uses: FiligranHQ/filigran-ci-tools/actions/check-signed-commit@main


### PR DESCRIPTION
### Proposed changes

* Add check signed commit workflow which uses ci-tools [action](https://github.com/FiligranHQ/filigran-ci-tools/blob/e1dff527972ee01c6f3b7d4955c5932fd0768531/actions/check-signed-commit/action.yml)

### Related issues

* Closes #154