### PR TITLE
[injector] feat(shodan): reintroduce assets and asset-groups parameters (#149)

### DIFF
--- a/shodan/shodan/__main__.py
+++ b/shodan/shodan/__main__.py
@@ -5,10 +5,10 @@ import os
 import sys
 from pathlib import Path
 
-from injector_common.dump_config import intercept_dump_argument
 from pydantic import ValidationError
 from pyoaev.helpers import OpenAEVConfigHelper, OpenAEVInjectorHelper
 
+from injector_common.dump_config import intercept_dump_argument
 from shodan.injector.openaev_shodan import ShodanInjector
 from shodan.models import ConfigLoader
 

--- a/shodan/shodan/__main__.py
+++ b/shodan/shodan/__main__.py
@@ -3,11 +3,12 @@
 import logging
 import os
 import sys
+from pathlib import Path
 
+from injector_common.dump_config import intercept_dump_argument
 from pydantic import ValidationError
 from pyoaev.helpers import OpenAEVConfigHelper, OpenAEVInjectorHelper
 
-from injector_common.dump_config import intercept_dump_argument
 from shodan.injector.openaev_shodan import ShodanInjector
 from shodan.models import ConfigLoader
 
@@ -25,12 +26,17 @@ def main() -> None:
         config = ConfigLoader()
         intercept_dump_argument(config.to_daemon_config())
 
+        # Load the injector icon for the helper
+        icon_bytes = (
+            Path(__file__).parents[1] / config.injector.icon_filepath
+        ).read_bytes()
+
         # Instantiate the OpenAEV injector helper
         helper = OpenAEVInjectorHelper(
             config=OpenAEVConfigHelper.from_configuration_object(
                 config.to_daemon_config()
             ),
-            icon=open("shodan/img/icon-shodan.png", "rb"),
+            icon=icon_bytes,
         )
 
         logger.info(

--- a/shodan/shodan/contracts/cloud_provider_asset_discovery/contract.py
+++ b/shodan/shodan/contracts/cloud_provider_asset_discovery/contract.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from pyoaev.contracts import ContractBuilder
 from pyoaev.contracts.contract_config import (
     Contract,
@@ -8,6 +10,9 @@ from pyoaev.contracts.contract_config import (
     ContractTuple,
     SupportedLanguage,
 )
+
+if TYPE_CHECKING:
+    from shodan.contracts.shodan_contracts import TargetSelectorField
 
 
 class CloudProviderAssetDiscovery:
@@ -24,8 +29,15 @@ class CloudProviderAssetDiscovery:
                     "icon": "CONFIG",
                     "title": "[CONFIG] Summary of all configurations used for the contract.",
                 },
-                "keys_list_to_string": ["cloud_provider"],
-                "keys_to_exclude": [],
+                "keys_list_to_string": ["cloud_provider", "hostnames"],
+                "keys_to_exclude": [
+                    "expectations",
+                    "selector_key",
+                    "asset_ids",
+                    "ips",
+                    "seen_ips",
+                    "assets",
+                ],
             },
             "sections_info": {
                 "header": {
@@ -127,39 +139,68 @@ class CloudProviderAssetDiscovery:
             },
         }
 
-    @staticmethod
+    @classmethod
+    def _build_conditions(
+        cls,
+        source_selector: str,
+        target_selector: list[str],
+        mandatory: bool = True,
+        visible: bool = True,
+    ):
+        conditions = {}
+        if mandatory:
+            conditions |= dict(
+                mandatoryConditionFields=[source_selector],
+                mandatoryConditionValues={source_selector: target_selector},
+            )
+        if visible:
+            conditions |= dict(
+                visibleConditionFields=[source_selector],
+                visibleConditionValues={source_selector: target_selector},
+            )
+        return conditions
+
+    @classmethod
     def contract_with_specific_fields(
+        cls,
         base_fields: list[ContractElement],
         source_selector_key: str,
-        target_selector_field: str,
+        target_selector_field: type["TargetSelectorField"],
     ) -> list[ContractElement]:
 
-        mandatory_conditions = dict(
-            mandatoryConditionFields=[source_selector_key],
-            mandatoryConditionValues={source_selector_key: target_selector_field},
-        )
-
-        visible_conditions = dict(
-            visibleConditionFields=[source_selector_key],
-            visibleConditionValues={source_selector_key: target_selector_field},
-        )
+        manual_target_selector = [target_selector_field.MANUAL.key]
+        all_targets_selector = [
+            target_selector_field.MANUAL.key,
+            target_selector_field.ASSETS.key,
+            target_selector_field.ASSET_GROUPS.key,
+        ]
 
         specific_fields = [
             ContractTuple(
                 key="cloud_provider",
                 label="Cloud Provider",
                 defaultValue=["Google", "Microsoft", "Amazon", "Azure"],
-                **(mandatory_conditions | visible_conditions),
+                **cls._build_conditions(
+                    source_selector=source_selector_key,
+                    target_selector=all_targets_selector,
+                ),
             ),
             ContractText(
                 key="hostname",
                 label="Hostname",
-                **(mandatory_conditions | visible_conditions),
+                **cls._build_conditions(
+                    source_selector=source_selector_key,
+                    target_selector=manual_target_selector,
+                ),
             ),
             ContractText(
                 key="organization",
                 label="Organization",
-                **visible_conditions,
+                **cls._build_conditions(
+                    source_selector=source_selector_key,
+                    target_selector=manual_target_selector,
+                    mandatory=False,
+                ),
             ),
         ]
 

--- a/shodan/shodan/contracts/critical_ports_and_exposed_admin_interface/contract.py
+++ b/shodan/shodan/contracts/critical_ports_and_exposed_admin_interface/contract.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from pyoaev.contracts import ContractBuilder
 from pyoaev.contracts.contract_config import (
     Contract,
@@ -8,6 +10,9 @@ from pyoaev.contracts.contract_config import (
     ContractTuple,
     SupportedLanguage,
 )
+
+if TYPE_CHECKING:
+    from shodan.contracts.shodan_contracts import TargetSelectorField
 
 
 class CriticalPortsAndExposedAdminInterface:
@@ -24,8 +29,15 @@ class CriticalPortsAndExposedAdminInterface:
                     "icon": "CONFIG",
                     "title": "[CONFIG] Summary of all configurations used for the contract.",
                 },
-                "keys_list_to_string": ["port"],
-                "keys_to_exclude": [],
+                "keys_list_to_string": ["port", "hostnames"],
+                "keys_to_exclude": [
+                    "expectations",
+                    "selector_key",
+                    "asset_ids",
+                    "ips",
+                    "seen_ips",
+                    "assets",
+                ],
             },
             "sections_info": {
                 "header": {
@@ -117,27 +129,47 @@ class CriticalPortsAndExposedAdminInterface:
             },
         }
 
-    @staticmethod
+    @classmethod
+    def _build_conditions(
+        cls,
+        source_selector: str,
+        target_selector: list[str],
+        mandatory: bool = True,
+        visible: bool = True,
+    ):
+        conditions = {}
+        if mandatory:
+            conditions |= dict(
+                mandatoryConditionFields=[source_selector],
+                mandatoryConditionValues={source_selector: target_selector},
+            )
+        if visible:
+            conditions |= dict(
+                visibleConditionFields=[source_selector],
+                visibleConditionValues={source_selector: target_selector},
+            )
+        return conditions
+
+    @classmethod
     def contract_with_specific_fields(
+        cls,
         base_fields: list[ContractElement],
         source_selector_key: str,
-        target_selector_field: str,
+        target_selector_field: type["TargetSelectorField"],
     ) -> list[ContractElement]:
 
-        mandatory_conditions = dict(
-            mandatoryConditionFields=[source_selector_key],
-            mandatoryConditionValues={source_selector_key: target_selector_field},
-        )
-
-        visible_conditions = dict(
-            visibleConditionFields=[source_selector_key],
-            visibleConditionValues={source_selector_key: target_selector_field},
-        )
+        manual_target_selector = [target_selector_field.MANUAL.key]
+        all_targets_selector = [
+            target_selector_field.MANUAL.key,
+            target_selector_field.ASSETS.key,
+            target_selector_field.ASSET_GROUPS.key,
+        ]
 
         specific_fields = [
             ContractTuple(
                 key="port",
                 label="Port",
+                mandatory=True,
                 defaultValue=[
                     "20",
                     "21",
@@ -161,17 +193,27 @@ class CriticalPortsAndExposedAdminInterface:
                     "5900",
                     "8080",
                 ],
-                **(mandatory_conditions | visible_conditions),
+                **cls._build_conditions(
+                    source_selector=source_selector_key,
+                    target_selector=all_targets_selector,
+                ),
             ),
             ContractText(
                 key="hostname",
                 label="Hostname",
-                **(mandatory_conditions | visible_conditions),
+                **cls._build_conditions(
+                    source_selector=source_selector_key,
+                    target_selector=manual_target_selector,
+                ),
             ),
             ContractText(
                 key="organization",
                 label="Organization",
-                **visible_conditions,
+                **cls._build_conditions(
+                    source_selector=source_selector_key,
+                    target_selector=manual_target_selector,
+                    mandatory=False,
+                ),
             ),
         ]
 

--- a/shodan/shodan/contracts/cve_enumeration/contract.py
+++ b/shodan/shodan/contracts/cve_enumeration/contract.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from pyoaev.contracts import ContractBuilder
 from pyoaev.contracts.contract_config import (
     Contract,
@@ -7,6 +9,9 @@ from pyoaev.contracts.contract_config import (
     ContractText,
     SupportedLanguage,
 )
+
+if TYPE_CHECKING:
+    from shodan.contracts.shodan_contracts import TargetSelectorField
 
 
 class CVEEnumeration:
@@ -23,8 +28,15 @@ class CVEEnumeration:
                     "icon": "CONFIG",
                     "title": "[CONFIG] Summary of all configurations used for the contract.",
                 },
-                "keys_list_to_string": [],
-                "keys_to_exclude": [],
+                "keys_list_to_string": ["hostnames"],
+                "keys_to_exclude": [
+                    "expectations",
+                    "selector_key",
+                    "asset_ids",
+                    "ips",
+                    "seen_ips",
+                    "assets",
+                ],
             },
             "sections_info": {
                 "header": {
@@ -116,33 +128,54 @@ class CVEEnumeration:
             },
         }
 
-    @staticmethod
+    @classmethod
+    def _build_conditions(
+        cls,
+        source_selector: str,
+        target_selector: list[str],
+        mandatory: bool = True,
+        visible: bool = True,
+    ):
+        conditions = {}
+        if mandatory:
+            conditions |= dict(
+                mandatoryConditionFields=[source_selector],
+                mandatoryConditionValues={source_selector: target_selector},
+            )
+        if visible:
+            conditions |= dict(
+                visibleConditionFields=[source_selector],
+                visibleConditionValues={source_selector: target_selector},
+            )
+        return conditions
+
+    @classmethod
     def contract_with_specific_fields(
+        cls,
         base_fields: list[ContractElement],
         source_selector_key: str,
-        target_selector_field: str,
+        target_selector_field: type["TargetSelectorField"],
     ) -> list[ContractElement]:
 
-        mandatory_conditions = dict(
-            mandatoryConditionFields=[source_selector_key],
-            mandatoryConditionValues={source_selector_key: target_selector_field},
-        )
-
-        visible_conditions = dict(
-            visibleConditionFields=[source_selector_key],
-            visibleConditionValues={source_selector_key: target_selector_field},
-        )
+        manual_target_selector = [target_selector_field.MANUAL.key]
 
         specific_fields = [
             ContractText(
                 key="hostname",
                 label="Hostname",
-                **(mandatory_conditions | visible_conditions),
+                **cls._build_conditions(
+                    source_selector=source_selector_key,
+                    target_selector=manual_target_selector,
+                ),
             ),
             ContractText(
                 key="organization",
                 label="Organization",
-                **visible_conditions,
+                **cls._build_conditions(
+                    source_selector=source_selector_key,
+                    target_selector=manual_target_selector,
+                    mandatory=False,
+                ),
             ),
         ]
 

--- a/shodan/shodan/contracts/domain_discovery/contract.py
+++ b/shodan/shodan/contracts/domain_discovery/contract.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from pyoaev.contracts import ContractBuilder
 from pyoaev.contracts.contract_config import (
     Contract,
@@ -7,6 +9,9 @@ from pyoaev.contracts.contract_config import (
     ContractText,
     SupportedLanguage,
 )
+
+if TYPE_CHECKING:
+    from shodan.contracts.shodan_contracts import TargetSelectorField
 
 
 class DomainDiscovery:
@@ -23,8 +28,15 @@ class DomainDiscovery:
                     "icon": "CONFIG",
                     "title": "[CONFIG] Summary of all configurations used for the contract.",
                 },
-                "keys_list_to_string": [],
-                "keys_to_exclude": [],
+                "keys_list_to_string": ["hostnames"],
+                "keys_to_exclude": [
+                    "expectations",
+                    "selector_key",
+                    "asset_ids",
+                    "ips",
+                    "seen_ips",
+                    "assets",
+                ],
             },
             "sections_info": {
                 "header": {
@@ -116,33 +128,54 @@ class DomainDiscovery:
             },
         }
 
-    @staticmethod
+    @classmethod
+    def _build_conditions(
+        cls,
+        source_selector: str,
+        target_selector: list[str],
+        mandatory: bool = True,
+        visible: bool = True,
+    ):
+        conditions = {}
+        if mandatory:
+            conditions |= dict(
+                mandatoryConditionFields=[source_selector],
+                mandatoryConditionValues={source_selector: target_selector},
+            )
+        if visible:
+            conditions |= dict(
+                visibleConditionFields=[source_selector],
+                visibleConditionValues={source_selector: target_selector},
+            )
+        return conditions
+
+    @classmethod
     def contract_with_specific_fields(
+        cls,
         base_fields: list[ContractElement],
         source_selector_key: str,
-        target_selector_field: str,
+        target_selector_field: type["TargetSelectorField"],
     ) -> list[ContractElement]:
 
-        mandatory_conditions = dict(
-            mandatoryConditionFields=[source_selector_key],
-            mandatoryConditionValues={source_selector_key: target_selector_field},
-        )
-
-        visible_conditions = dict(
-            visibleConditionFields=[source_selector_key],
-            visibleConditionValues={source_selector_key: target_selector_field},
-        )
+        manual_target_selector = [target_selector_field.MANUAL.key]
 
         specific_fields = [
             ContractText(
                 key="hostname",
                 label="Hostname",
-                **(mandatory_conditions | visible_conditions),
+                **cls._build_conditions(
+                    source_selector=source_selector_key,
+                    target_selector=manual_target_selector,
+                ),
             ),
             ContractText(
                 key="organization",
                 label="Organization",
-                **visible_conditions,
+                **cls._build_conditions(
+                    source_selector=source_selector_key,
+                    target_selector=manual_target_selector,
+                    mandatory=False,
+                ),
             ),
         ]
 

--- a/shodan/shodan/contracts/shodan_contracts.py
+++ b/shodan/shodan/contracts/shodan_contracts.py
@@ -267,7 +267,7 @@ class ShodanContracts:
             contract_with_specific_fields=contract_cls.contract_with_specific_fields(
                 base_fields=self._base_fields(contract_selector_default),
                 source_selector_key=InjectorKey.TARGET_SELECTOR_KEY,
-                target_selector_field=TargetSelectorField.MANUAL.key,
+                target_selector_field=TargetSelectorField,
             ),
             contract_with_specific_outputs=contract_cls.contract_with_specific_outputs(
                 self._base_outputs()
@@ -276,7 +276,7 @@ class ShodanContracts:
 
     def contracts(self):
 
-        selector_default = "only_manual"
+        selector_default = TargetSelectorField.ASSET_GROUPS.key
 
         shodan_contract_definitions = [
             (
@@ -289,7 +289,7 @@ class ShodanContracts:
                 CriticalPortsAndExposedAdminInterface,
                 selector_default,
             ),
-            (ShodanContractId.CUSTOM_QUERY, CustomQuery, selector_default),
+            (ShodanContractId.CUSTOM_QUERY, CustomQuery, "only_manual"),
             (ShodanContractId.CVE_ENUMERATION, CVEEnumeration, selector_default),
             (
                 ShodanContractId.CVE_SPECIFIC_WATCHLIST,

--- a/shodan/shodan/injector/openaev_shodan.py
+++ b/shodan/shodan/injector/openaev_shodan.py
@@ -1,9 +1,9 @@
 import time
 from datetime import datetime, timezone
 
-from injector_common.pagination import Pagination
 from pyoaev.helpers import OpenAEVInjectorHelper
 
+from injector_common.pagination import Pagination
 from shodan.contracts import (
     CloudProviderAssetDiscovery,
     CriticalPortsAndExposedAdminInterface,

--- a/shodan/shodan/models/__init__.py
+++ b/shodan/shodan/models/__init__.py
@@ -1,3 +1,37 @@
+from shodan.models.client_api import (
+    ContractHTTPDefinition,
+    FilterDefinition,
+    Operator,
+    ShodanRestAPI,
+)
 from shodan.models.configs.config_loader import ConfigLoader
+from shodan.models.exceptions import (
+    InvalidContractError,
+    InvalidTargetFieldError,
+    InvalidTargetPropertySelectorError,
+    MissingRequiredFieldError,
+    NoTargetsRecovered,
+)
+from shodan.models.normalize_input_data import (
+    ContractType,
+    InjectContentType,
+    NormalizeInputData,
+    TargetsType,
+)
 
-__all__ = ["ConfigLoader"]
+__all__ = [
+    "ConfigLoader",
+    "NormalizeInputData",
+    "InjectContentType",
+    "TargetsType",
+    "MissingRequiredFieldError",
+    "InvalidContractError",
+    "InvalidTargetPropertySelectorError",
+    "InvalidTargetFieldError",
+    "NoTargetsRecovered",
+    "ShodanRestAPI",
+    "ContractType",
+    "ContractHTTPDefinition",
+    "FilterDefinition",
+    "Operator",
+]

--- a/shodan/shodan/models/client_api.py
+++ b/shodan/shodan/models/client_api.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Union
+
+from pydantic import BaseModel, Field
+
+
+@dataclass
+class ShodanRestAPIDefinition:
+    http_method: str
+    endpoint: str
+
+
+class ShodanRestAPI(Enum):
+    SEARCH_SHODAN = ShodanRestAPIDefinition(
+        http_method="GET",
+        endpoint="shodan/host/search",
+    )
+    API_PLAN_INFORMATION = ShodanRestAPIDefinition(
+        http_method="GET",
+        endpoint="api-info",
+    )
+
+    @property
+    def http_method(self) -> str:
+        return self.value.http_method
+
+    @property
+    def endpoint(self) -> str:
+        return self.value.endpoint
+
+
+class Operator(str, Enum):
+    AND = "and"
+    OR = "or"
+
+
+class FilterDefinition(BaseModel):
+    value: Union[str, list[str]]
+    operator: Operator | None = Field(default=None)
+
+
+class ContractHTTPDefinition(BaseModel):
+    target_field: str = Field(default="hostname")
+    required_fields: list[str]
+    filters: dict[str, FilterDefinition] | None = Field(default=None)

--- a/shodan/shodan/models/exceptions.py
+++ b/shodan/shodan/models/exceptions.py
@@ -1,0 +1,34 @@
+class ShodanClientError(Exception):
+    """Base class for all Shodan client exceptions."""
+
+    pass
+
+
+class MissingRequiredFieldError(ShodanClientError):
+    """Raised when a required field is missing in the input data."""
+
+    pass
+
+
+class InvalidContractError(ShodanClientError):
+    """Raised when a provided contract ID or name is invalid."""
+
+    pass
+
+
+class InvalidTargetPropertySelectorError(ShodanClientError):
+    """Raised when the target property selector is unsupported or invalid."""
+
+    pass
+
+
+class InvalidTargetFieldError(ShodanClientError):
+    """Raised when a target field is unsupported or invalid."""
+
+    pass
+
+
+class NoTargetsRecovered(ShodanClientError):
+    """Raised when no targets could be resolved from input data."""
+
+    pass

--- a/shodan/shodan/models/normalize_input_data.py
+++ b/shodan/shodan/models/normalize_input_data.py
@@ -1,0 +1,134 @@
+import re
+from enum import Enum
+from typing import Annotated, Literal, Union
+
+from pydantic import BaseModel, BeforeValidator, Discriminator, field_validator
+
+EmptyStrToFalse = Annotated[
+    bool, BeforeValidator(lambda v: False if v in ("", None) else v)
+]
+
+
+def _parse_values(values: Union[str, list[str]]) -> list[str]:
+    if isinstance(values, str):
+        return [value.strip() for value in re.split(r"[,\s]+", values) if value.strip()]
+    elif isinstance(values, list):
+        return [v.strip() for v in values if v.strip()]
+    return []
+
+
+class InjectContent(BaseModel):
+    expectations: list[dict]
+    target_selector: str
+    target_property_selector: str
+    auto_create_assets: EmptyStrToFalse
+
+
+class ContractFieldsCommon(InjectContent):
+    hostname: list[str]
+    organization: list[str] | None
+
+    @field_validator("hostname", "organization", mode="before")
+    def parse_hostname_and_organization(cls, values):
+        return _parse_values(values)
+
+
+class DomainDiscovery(ContractFieldsCommon):
+    contract: Literal["domain_discovery"]
+    pass
+
+
+class CVEEnumeration(ContractFieldsCommon):
+    contract: Literal["cve_enumeration"]
+    pass
+
+
+class CVESpecificWatchlist(ContractFieldsCommon):
+    contract: Literal["cve_specific_watchlist"]
+    vulnerability: list[str]
+
+    @field_validator("vulnerability", mode="before")
+    def parse_vulnerability(cls, values):
+        return _parse_values(values)
+
+
+class CustomQuery(InjectContent):
+    contract: Literal["custom_query"]
+    http_method: str
+    custom_query: str
+
+
+class IPEnumeration(InjectContent):
+    contract: Literal["ip_enumeration"]
+    ip: list[str]
+
+    @field_validator("ip", mode="before")
+    def parse_ip(cls, values):
+        return _parse_values(values)
+
+
+class CriticalPortsAndExposedAdminInterface(ContractFieldsCommon):
+    contract: Literal["critical_ports_and_exposed_admin_interface"]
+    port: list[str]
+
+    @field_validator("port", mode="before")
+    def parse_port(cls, values):
+        return _parse_values(values)
+
+
+class CloudProviderAssetDiscovery(ContractFieldsCommon):
+    contract: Literal["cloud_provider_asset_discovery"]
+    cloud_provider: list[str]
+
+    @field_validator("cloud_provider", mode="before")
+    def parse_cloud_provider(cls, values):
+        return _parse_values(values)
+
+
+InjectContentType = Annotated[
+    Union[
+        DomainDiscovery,
+        CustomQuery,
+        CVEEnumeration,
+        CVESpecificWatchlist,
+        CriticalPortsAndExposedAdminInterface,
+        CloudProviderAssetDiscovery,
+        IPEnumeration,
+    ],
+    Discriminator("contract"),
+]
+
+
+class ContractType(str, Enum):
+    DOMAIN_DISCOVERY = "domain_discovery"
+    CVE_ENUMERATION = "cve_enumeration"
+    CVE_SPECIFIC_WATCHLIST = "cve_specific_watchlist"
+    CUSTOM_QUERY = "custom_query"
+    IP_ENUMERATION = "ip_enumeration"
+    CRITICAL_PORTS_AND_EXPOSED_ADMIN_INTERFACE = (
+        "critical_ports_and_exposed_admin_interface"
+    )
+    CLOUD_PROVIDER_ASSET_DISCOVERY = "cloud_provider_asset_discovery"
+
+
+class AssetsType(BaseModel):
+    asset_id: str
+    endpoint_hostname: str | None
+    endpoint_ips: list[str]
+    endpoint_seen_ip: str | None
+
+
+class TargetsType(BaseModel):
+    selector_key: str
+    asset_ids: list[str]
+    hostnames: list[str]
+    ips: list[str]
+    seen_ips: list[str]
+    assets: list[AssetsType]
+
+
+class NormalizeInputData(BaseModel):
+    contract_name: str
+    contract_id: str
+    inject_content: InjectContentType
+    targets: TargetsType

--- a/shodan/shodan/services/client_api.py
+++ b/shodan/shodan/services/client_api.py
@@ -1,6 +1,4 @@
-import re
-from dataclasses import dataclass
-from enum import Enum
+from typing import Any, Union
 from urllib.parse import quote_plus, urljoin
 
 import requests
@@ -8,38 +6,23 @@ from limiter import Limiter
 from pyoaev.helpers import OpenAEVInjectorHelper
 from tenacity import RetryError, retry, stop_after_attempt, wait_exponential_jitter
 
-from shodan.contracts import ShodanContractId
-from shodan.models import ConfigLoader
+from shodan.models import (
+    ConfigLoader,
+    ContractHTTPDefinition,
+    FilterDefinition,
+    InjectContentType,
+    InvalidContractError,
+    InvalidTargetFieldError,
+    InvalidTargetPropertySelectorError,
+    MissingRequiredFieldError,
+    NormalizeInputData,
+    NoTargetsRecovered,
+    Operator,
+    ShodanRestAPI,
+    TargetsType,
+)
 
 LOG_PREFIX = "[SHODAN_CLIENT_API]"
-
-
-class MissingRequiredFieldError(ValueError):
-    pass
-
-
-@dataclass
-class ShodanRestAPIDefinition:
-    http_method: str
-    endpoint: str
-
-
-class ShodanRestAPI(Enum):
-    SEARCH_SHODAN = ShodanRestAPIDefinition(
-        http_method="GET",
-        endpoint="shodan/host/search",
-    )
-    API_PLAN_INFORMATION = ShodanRestAPIDefinition(
-        http_method="GET", endpoint="api-info"
-    )
-
-    @property
-    def http_method(self) -> str:
-        return self.value.http_method
-
-    @property
-    def endpoint(self) -> str:
-        return self.value.endpoint
 
 
 class ShodanClientAPI:
@@ -64,11 +47,15 @@ class ShodanClientAPI:
         )
 
     @staticmethod
-    def _split_target(raw_input: str) -> list[str]:
-        return [target for target in re.split(r"[,\s]+", raw_input or "") if target]
-
-    @staticmethod
     def _secure_url(url: str) -> str:
+        """Removes the API key from a URL for logging or display purposes.
+        This is necessary to prevent the Shodan API key from being exposed in logs or debug output.
+        Args:
+            url (str): The URL potentially containing an API key.
+        Returns:
+            str: The URL without the API key.
+        """
+
         if not url:
             return url
         if "?query" in url:
@@ -76,7 +63,18 @@ class ShodanClientAPI:
         return url.split("?key=")[0]
 
     @staticmethod
-    def _build_query(query_params: dict[str, tuple[str, str]]) -> str:
+    def _build_query(query_params: dict[str, tuple[str, Operator]]) -> str:
+        """Constructs a Shodan query string from filter parameters.
+        Each item in `query_params` is a tuple of (value, operator) where operator can be 'and', 'or', or None.
+        The resulting string is used for use in the Shodan search URL.
+
+        Args:
+            query_params (dict[str, tuple[str, Operator]]): Dictionary mapping filter keys to (value, operator).
+
+        Returns:
+            str: A Shodan query string.
+        """
+
         query = ["query="]
         for key, (value, operator) in query_params.items():
             if operator == "and":
@@ -94,6 +92,17 @@ class ShodanClientAPI:
         query_params: str | None = None,
         is_custom_query: bool = False,
     ) -> str:
+        """Builds a full Shodan API URL including the endpoint, query parameters, and API key.
+
+        Args:
+            endpoint (str): The API endpoint (relative path).
+            query_params (str | None): Encoded query string to append to the URL.
+            is_custom_query (bool): Whether the query is a custom query requiring special handling.
+
+        Returns:
+            str: Fully constructed URL ready to be requested.
+        """
+
         url = urljoin(self.base_url, endpoint)
         api_key = f"key={self.api_key.get_secret_value()}"
         if not query_params and "?query=" not in url:
@@ -103,172 +112,51 @@ class ShodanClientAPI:
         return f"{url}?{query_params}&{api_key}"
 
     # SECTION INFO
-    def _get_user_info(self):
+    def _get_user_info(self) -> dict[str, Any]:
+        """Retrieves the user's Shodan account information and quota.
+
+        Returns:
+            dict[str, Any]: Dictionary containing user account information from Shodan.
+        """
         self.helper.injector_logger.info(
             f"{LOG_PREFIX} - Preparation for user quota recovery...",
         )
 
         return self._process_request(
-            raw_input="user_info",
+            raw_input=["user_info"],
             request_api=ShodanRestAPI.API_PLAN_INFORMATION,
-        )
-
-    # CONTRACT - CVE ENUMERATION
-    def _get_cve_enumeration(self, inject_content):
-        hostname = inject_content.get("hostname")
-        if not hostname:
-            raise MissingRequiredFieldError(
-                f"{LOG_PREFIX} - The 'Hostname' field is required and cannot be empty."
-            )
-
-        filters = {
-            "has_vuln": ("true", "and"),
-            "hostname": ("{target},*.{target}", "or"),
-            "org": (inject_content.get("organization") or "{target}", "end"),
-        }
-        return self._process_request(
-            raw_input=hostname,
-            request_api=ShodanRestAPI.SEARCH_SHODAN,
-            filters_template=filters,
-        )
-
-    # CONTRACT - CVE SPECIFIC WATCHLIST
-    def _get_cve_specific_watchlist(self, inject_content):
-        hostname = inject_content.get("hostname")
-        if not hostname:
-            raise MissingRequiredFieldError(
-                f"{LOG_PREFIX} - The 'Hostname' field is required and cannot be empty."
-            )
-
-        filters = {
-            "vuln": (inject_content.get("vulnerability"), "and"),
-            "hostname": ("{target},*.{target}", "and"),
-            "org": (inject_content.get("organization") or "{target}", "end"),
-        }
-        return self._process_request(
-            raw_input=hostname,
-            request_api=ShodanRestAPI.SEARCH_SHODAN,
-            filters_template=filters,
-        )
-
-    # CONTRACT - CLOUD PROVIDER ASSET DISCOVERY
-    def _get_cloud_provider_asset_discovery(self, inject_content):
-        hostname = inject_content.get("hostname")
-        if not hostname:
-            raise MissingRequiredFieldError(
-                f"{LOG_PREFIX} - The 'Hostname' field is required and cannot be empty."
-            )
-
-        cloud_provider = inject_content.get("cloud_provider")
-        # Please note that the default values are by nature a list.
-        if isinstance(cloud_provider, list):
-            cloud_provider = ",".join(cloud_provider)
-
-        filters = {
-            "cloud.provider": (cloud_provider, "and"),
-            "hostname": ("{target},*.{target}", "or"),
-            "org": (inject_content.get("organization") or "{target}", "end"),
-        }
-        return self._process_request(
-            raw_input=hostname,
-            request_api=ShodanRestAPI.SEARCH_SHODAN,
-            filters_template=filters,
-        )
-
-    # CONTRACT - CRITICAL PORTS AND EXPOSED ADMIN INTERFACE
-    def _get_critical_ports_and_exposed_admin_interface(self, inject_content):
-        hostname = inject_content.get("hostname")
-        if not hostname:
-            raise MissingRequiredFieldError(
-                f"{LOG_PREFIX} - The 'Hostname' field is required and cannot be empty."
-            )
-
-        port = inject_content.get("port")
-        # Please note that the default values are by nature a list.
-        if isinstance(port, list):
-            port = ",".join(port)
-
-        filters = {
-            "port": (port, "and"),
-            "hostname": ("{target},*.{target}", "or"),
-            "org": (inject_content.get("organization") or "{target}", "end"),
-        }
-        return self._process_request(
-            raw_input=hostname,
-            request_api=ShodanRestAPI.SEARCH_SHODAN,
-            filters_template=filters,
-        )
-
-    # CONTRACT - CUSTOM QUERY
-    def _get_custom_query(self, inject_content):
-        custom_query = inject_content.get("custom_query")
-        http_method = inject_content.get("http_method")
-        if not custom_query:
-            raise MissingRequiredFieldError(
-                f"{LOG_PREFIX} - The 'Custom Query' field is required and cannot be empty."
-            )
-
-        return self._process_request(
-            raw_input=custom_query,
-            request_api=None,
-            filters_template=None,
-            is_custom_query=True,
-            http_method_custom_query=http_method,
-        )
-
-    # CONTRACT - DOMAIN DISCOVERY
-    def _get_domain_discovery(self, inject_content):
-        hostname = inject_content.get("hostname")
-        if not hostname:
-            raise MissingRequiredFieldError(
-                f"{LOG_PREFIX} - The 'hostname' field is required and cannot be empty."
-            )
-
-        filters = {
-            "hostname": ("{target},*.{target}", "or"),
-            "org": (inject_content.get("organization") or "{target}", "end"),
-        }
-        return self._process_request(
-            raw_input=hostname,
-            request_api=ShodanRestAPI.SEARCH_SHODAN,
-            filters_template=filters,
-        )
-
-    # CONTRACT - IP ENUMERATION
-    def _get_ip_enumeration(self, inject_content):
-        ip = inject_content.get("ip")
-        if not ip:
-            raise MissingRequiredFieldError(
-                f"{LOG_PREFIX} - The 'ip' field is required and cannot be empty."
-            )
-
-        filters = {
-            "ip": ("{target}", "end"),
-        }
-
-        return self._process_request(
-            raw_input=ip,
-            request_api=ShodanRestAPI.SEARCH_SHODAN,
-            filters_template=filters,
         )
 
     def _process_request(
         self,
-        raw_input: str,
+        raw_input: list[str] | str,
         request_api: ShodanRestAPI | None,
-        filters_template: dict = None,
+        filters_template: dict[str, FilterDefinition] | None = None,
         is_custom_query: bool = False,
         http_method_custom_query: str | None = None,
-    ):
+    ) -> Union[dict[str, Any], Any]:
+        """Sends a request to Shodan for the given targets and filters, handling retries and errors.
+        This method constructs the query URL, applies optional filters, encodes it, and calls "_request_data".
 
-        if is_custom_query:
-            targets = [raw_input]
-            http_method = http_method_custom_query
-            endpoint_template = raw_input
-        else:
-            targets = self._split_target(raw_input)
-            http_method = request_api.value.http_method
-            endpoint_template = request_api.value.endpoint
+        Args:
+            raw_input (list[str] | str): List of targets or a single target string.
+            request_api (ShodanRestAPI | None): The API endpoint definition to use.
+            filters_template (dict[str, FilterDefinition] | None): Optional filters to apply to the query.
+            is_custom_query (bool): Whether this is a custom query bypassing standard contract endpoints.
+            http_method_custom_query (str | None): HTTP method to use for a custom query.
+
+        Returns:
+             Union[dict[str, Any], Any]: Either a structured dictionary with targets and results, or the raw API
+                response for special queries.
+        """
+
+        targets = [raw_input] if is_custom_query else raw_input
+        http_method = (
+            http_method_custom_query
+            if is_custom_query
+            else request_api.value.http_method
+        )
+        endpoint_template = raw_input if is_custom_query else request_api.value.endpoint
 
         result = None
         results = []
@@ -278,12 +166,25 @@ class ShodanClientAPI:
             encoded_for_shodan = None
 
             if filters_template:
-                filters = {}
-                for key, (target_value, operator) in filters_template.items():
-                    filters[key] = (target_value.format(target=target), operator)
+                filters_dict = {}
+                for key, filter_definition in filters_template.items():
+                    if isinstance(filter_definition.value, list):
+                        value_resolved = ",".join(
+                            str(v) for v in filter_definition.value
+                        )
+                    elif (
+                        isinstance(filter_definition.value, str)
+                        and "{target}" in filter_definition.value
+                    ):
+                        value_resolved = filter_definition.value.format(target=target)
+                    else:
+                        value_resolved = filter_definition.value
 
-                query_params = self._build_query(filters)
+                    filters_dict[key] = (value_resolved, filter_definition.operator)
+
+                query_params = self._build_query(filters_dict)
                 encoded_for_shodan = quote_plus(query_params, safe="=:,*.")
+
             target_url = self._build_url(
                 endpoint=new_endpoint,
                 query_params=encoded_for_shodan if filters_template else query_params,
@@ -332,7 +233,21 @@ class ShodanClientAPI:
             else {"targets": targets, "data": results}
         )
 
-    def _request_data(self, method: str, url: str):
+    def _request_data(self, method: str, url: str) -> dict[str, Any]:
+        """Sends an HTTP request to the given URL using the specified method, with built-in retry and rate limiting
+        mechanisms.
+
+        Args:
+            method (str): The HTTP method to use for the request.
+            url (str): The full URL to send the request to.
+
+        Returns:
+            dict[str, Any]: The parsed JSON response from the API.
+
+        Raises:
+            tenacity.RetryError: If all retry attempts fail.
+        """
+
         @retry(
             stop=stop_after_attempt(max_attempt_number=self.api_retry),
             wait=wait_exponential_jitter(
@@ -347,31 +262,237 @@ class ShodanClientAPI:
         with self.rate_limiter:
             return _retry_wrapped()
 
+    def _execute_contract(
+        self,
+        inject_content: InjectContentType,
+        targets: TargetsType,
+        contract_http_definition: ContractHTTPDefinition,
+    ) -> dict[str, Any]:
+        """Execute a Shodan contract based on the provided inject content and targets.
+
+        This method resolves the targets depending on the target selector:
+        - If `manual`, it validates that all required fields in the contract are provided in `inject_content`.
+          If the contract is a `custom_query`, it directly processes the custom query.
+        - If `automatic`, it selects the targets based on the `target_property_selector` and `target_field`.
+
+        Once targets are resolved, the method invokes `_process_request` to query Shodan
+        and return the structured results.
+
+        Args:
+            inject_content (InjectContentType): Object containing information injected by the user.
+            targets (TargetsType): targets contains target information if assets or asset-groups, or is empty if manual.
+            contract_http_definition (ContractHTTPDefinition): Object containing the definition of the selected contract.
+
+        Returns:
+            dict[str, Any]: Dictionary containing the results of the Shodan search.
+        """
+        target_selector = inject_content.target_selector
+        target_field = contract_http_definition.target_field
+        required_fields = contract_http_definition.required_fields
+
+        if target_selector == "manual":
+            for required_field in required_fields:
+                field = getattr(inject_content, required_field, None)
+                if field in (None, "", []):
+                    self.helper.injector_logger.error(
+                        f"{LOG_PREFIX} - The field is required and cannot be empty.",
+                        {"required_field": required_field},
+                    )
+                    raise MissingRequiredFieldError(
+                        f"{LOG_PREFIX} - The field is required and cannot be empty."
+                    )
+
+            resolved_targets = getattr(inject_content, target_field, None)
+
+            if inject_content.contract == "custom_query":
+                return self._process_request(
+                    raw_input=inject_content.custom_query,
+                    request_api=None,
+                    filters_template=None,
+                    is_custom_query=True,
+                    http_method_custom_query=inject_content.http_method,
+                )
+        else:
+            target_property_selector = inject_content.target_property_selector
+            mapping_target_property = {
+                "ip": {
+                    "automatic": targets.ips + targets.seen_ips,
+                    "local_ip": targets.ips,
+                    "seen_ip": targets.seen_ips,
+                },
+                "hostname": {
+                    "automatic": targets.hostnames,
+                    "hostname": targets.hostnames,
+                },
+            }
+
+            if target_field not in mapping_target_property:
+                self.helper.injector_logger.error(
+                    f"{LOG_PREFIX} - Invalid target field.",
+                    {"target_field": target_field},
+                )
+                raise InvalidTargetFieldError(f"{LOG_PREFIX} - Invalid target field.")
+
+            available_targets = mapping_target_property.get(target_field)
+            if target_property_selector not in available_targets:
+                self.helper.injector_logger.error(
+                    f"{LOG_PREFIX} - Invalid target property selector.",
+                    {"target_property_selector": target_property_selector},
+                )
+                raise InvalidTargetPropertySelectorError(
+                    f"{LOG_PREFIX} - Invalid target property selector."
+                )
+
+            resolved_targets = available_targets.get(target_property_selector)
+
+        if not resolved_targets:
+            self.helper.injector_logger.error(
+                f"{LOG_PREFIX} - No targets were recovered for the contract.",
+            )
+            raise NoTargetsRecovered(
+                f"{LOG_PREFIX} - No targets were recovered for the contract."
+            )
+
+        return self._process_request(
+            raw_input=resolved_targets,
+            request_api=ShodanRestAPI.SEARCH_SHODAN,
+            filters_template=contract_http_definition.filters,
+        )
+
+    def _get_contract_http_definition(
+        self, inject_content: InjectContentType
+    ) -> ContractHTTPDefinition:
+        """Retrieves the HTTP contract definition corresponding to the injected content.
+            This method selects the appropriate HTTP contract from a list of predefined contracts, based on the value
+            of inject_content.contract.
+
+        Args:
+            inject_content (InjectContentType): Object containing information injected by the user, including the
+                contract name and possible fields such as organization, port, vulnerability or cloud_provider.
+
+        Returns:
+            ContractHTTPDefinition: Object containing the complete definition of the selected contract, with the
+                required fields and associated filters.
+        """
+
+        hostname_and_org_filters = {
+            "hostname": FilterDefinition(
+                value="{target},*.{target}",
+                operator=Operator.OR,
+            ),
+            "org": FilterDefinition(
+                value=getattr(inject_content, "organization", []) or "{target}",
+            ),
+        }
+
+        contract_http_definitions = {
+            "domain_discovery": ContractHTTPDefinition(
+                required_fields=["hostname"],
+                filters={
+                    **hostname_and_org_filters,
+                },
+            ),
+            "ip_enumeration": ContractHTTPDefinition(
+                target_field="ip",
+                required_fields=["ip"],
+                filters={
+                    "ip": FilterDefinition(
+                        value="{target}",
+                    )
+                },
+            ),
+            "cve_enumeration": ContractHTTPDefinition(
+                required_fields=["hostname"],
+                filters={
+                    "has_vuln": FilterDefinition(value="true", operator=Operator.AND),
+                    **hostname_and_org_filters,
+                },
+            ),
+            "cve_specific_watchlist": ContractHTTPDefinition(
+                required_fields=["vulnerability", "hostname"],
+                filters={
+                    "vuln": FilterDefinition(
+                        value=getattr(inject_content, "vulnerability", []),
+                        operator=Operator.AND,
+                    ),
+                    **hostname_and_org_filters,
+                },
+            ),
+            "critical_ports_and_exposed_admin_interface": ContractHTTPDefinition(
+                required_fields=["port", "hostname"],
+                filters={
+                    "port": FilterDefinition(
+                        value=getattr(inject_content, "port", []),
+                        operator=Operator.AND,
+                    ),
+                    **hostname_and_org_filters,
+                },
+            ),
+            "cloud_provider_asset_discovery": ContractHTTPDefinition(
+                required_fields=["cloud_provider", "hostname"],
+                filters={
+                    "cloud.provider": FilterDefinition(
+                        value=getattr(inject_content, "cloud_provider", []),
+                        operator=Operator.AND,
+                    ),
+                    **hostname_and_org_filters,
+                },
+            ),
+            "custom_query": ContractHTTPDefinition(
+                target_field="custom_query",
+                required_fields=["custom_query"],
+                filters=None,
+            ),
+        }
+
+        contract_http_definition = contract_http_definitions[inject_content.contract]
+
+        if not contract_http_definition:
+            self.helper.injector_logger.error(
+                f"{LOG_PREFIX} - The contract name is invalid.",
+                {"contract_name": inject_content.contract},
+            )
+            raise InvalidContractError(f"{LOG_PREFIX} - The contract name is invalid.")
+
+        return contract_http_definition
+
     def process_shodan_search(
-        self, contract_id: ShodanContractId, inject_content: dict
-    ):
+        self, normalize_input_data: NormalizeInputData
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """The main process that triggers the Shodan search.
+
+        It begins by retrieving all the information provided by the user (inject_content and targets), then retrieves
+        the definition of the corresponding contract, executes the Shodan search for these targets, and finally
+        retrieves the user's quota information.
+
+        Args:
+            normalize_input_data (NormalizeInputData): Object containing all information about the content injected by
+                the user and/or the targets.
+
+        Returns:
+            tuple[dict[str, Any], dict[str, Any]]:
+                - The first dictionary (results) contains the results of the Shodan search, structured by target.
+                - The second dictionary (shodan_credit_user) contains the user information (quota) retrieved from Shodan.
+
+        Raises:
+            MissingRequiredFieldError: Raised when a required field is missing in the input data.
+            InvalidContractError: Raised when a provided contract ID or name is invalid.
+            InvalidTargetPropertySelectorError: Raised when the target property selector is unsupported or invalid.
+            InvalidTargetFieldError: Raised when a target field is unsupported or invalid.
+            NoTargetsRecovered: Raised when no targets could be resolved from input data.
+        """
+
         self.helper.injector_logger.info(
             f"{LOG_PREFIX} - Starting the Shodan search process...",
         )
-        contract_handler = {
-            ShodanContractId.CVE_ENUMERATION: self._get_cve_enumeration,
-            ShodanContractId.CVE_SPECIFIC_WATCHLIST: self._get_cve_specific_watchlist,
-            ShodanContractId.CLOUD_PROVIDER_ASSET_DISCOVERY: self._get_cloud_provider_asset_discovery,
-            ShodanContractId.CRITICAL_PORTS_AND_EXPOSED_ADMIN_INTERFACE: self._get_critical_ports_and_exposed_admin_interface,
-            ShodanContractId.CUSTOM_QUERY: self._get_custom_query,
-            ShodanContractId.DOMAIN_DISCOVERY: self._get_domain_discovery,
-            ShodanContractId.IP_ENUMERATION: self._get_ip_enumeration,
-        }
+        inject_content = normalize_input_data.inject_content
+        targets = normalize_input_data.targets
 
-        contract = contract_handler.get(contract_id)
-        if not contract:
-            self.helper.injector_logger.error(
-                f"{LOG_PREFIX} - The contract ID is invalid.",
-                {"contract_id": contract_id},
-            )
-            raise ValueError(f"{LOG_PREFIX} - The contract ID is invalid.")
+        contract_http_definition = self._get_contract_http_definition(inject_content)
+        results = self._execute_contract(
+            inject_content, targets, contract_http_definition
+        )
 
-        results = contract(inject_content)
         shodan_credit_user = self._get_user_info()
 
         self.helper.injector_logger.info(

--- a/shodan/shodan/services/utils.py
+++ b/shodan/shodan/services/utils.py
@@ -79,7 +79,7 @@ class Utils:
                             parts.extend(f"{k}:{v}" for k, v in item.items())
                         else:
                             parts.append(str(item))
-                    value = ",".join(parts)
+                    value = ", ".join(parts)
 
                 self._add_value_to_tree(tree, key, value)
 

--- a/shodan/tests/conftest.py
+++ b/shodan/tests/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 from pytest import fixture
 
+from shodan.injector.openaev_shodan import ShodanInjector
 from shodan.services.client_api import ShodanClientAPI
 
 
@@ -53,3 +54,19 @@ def shodan_client_api() -> ShodanClientAPI:
     mock_helper = Mock()
 
     return ShodanClientAPI(config=mock_config, helper=mock_helper)
+
+
+@fixture
+def shodan_injector() -> ShodanInjector:
+    """Provide a ShodanInjector with mocked config and helper."""
+    mock_config = Mock()
+    mock_config.shodan.base_url = "https://api.shodan.io"
+    mock_config.shodan.api_key.get_secret_value.return_value = "test-api-key"
+    mock_config.shodan.api_retry = 1
+    mock_config.shodan.api_backoff.total_seconds.return_value = 1
+    mock_config.shodan.api_leaky_bucket_rate = 10
+    mock_config.shodan.api_leaky_bucket_capacity = 10
+
+    mock_helper = Mock()
+
+    return ShodanInjector(config=mock_config, helper=mock_helper)

--- a/shodan/tests/shodan_api/constraints/test_organization_defaults_to_hostname.py
+++ b/shodan/tests/shodan_api/constraints/test_organization_defaults_to_hostname.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 import pytest
 
-from shodan.contracts import InjectorKey, ShodanContractId
 from shodan.injector.openaev_shodan import ShodanInjector
 from shodan.models import NormalizeInputData
 from shodan.services.client_api import ShodanClientAPI

--- a/shodan/tests/shodan_contracts/cloud_provider_asset_discovery/test_cloud_provider_asset_discovery.py
+++ b/shodan/tests/shodan_contracts/cloud_provider_asset_discovery/test_cloud_provider_asset_discovery.py
@@ -4,9 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from shodan.contracts import InjectorKey, ShodanContractId
 from shodan.models.normalize_input_data import (
-    AssetsType,
     CloudProviderAssetDiscovery,
     NormalizeInputData,
     TargetsType,

--- a/shodan/tests/shodan_contracts/constraints/test_results_no_found.py
+++ b/shodan/tests/shodan_contracts/constraints/test_results_no_found.py
@@ -1,9 +1,8 @@
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
 from shodan.contracts import ShodanContractId
-from shodan.injector.openaev_shodan import ShodanInjector
 from shodan.models import NormalizeInputData
 from shodan.services.client_api import ShodanClientAPI
 

--- a/shodan/tests/shodan_contracts/critical_ports_and_exposed_admin_interface/test_critical_ports_and_exposed_admin_interface.py
+++ b/shodan/tests/shodan_contracts/critical_ports_and_exposed_admin_interface/test_critical_ports_and_exposed_admin_interface.py
@@ -4,9 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from shodan.contracts import InjectorKey, ShodanContractId
 from shodan.models.normalize_input_data import (
-    AssetsType,
     CriticalPortsAndExposedAdminInterface,
     NormalizeInputData,
     TargetsType,

--- a/shodan/tests/shodan_contracts/critical_ports_and_exposed_admin_interface/test_critical_ports_and_exposed_admin_interface.py
+++ b/shodan/tests/shodan_contracts/critical_ports_and_exposed_admin_interface/test_critical_ports_and_exposed_admin_interface.py
@@ -5,6 +5,12 @@ from unittest.mock import patch
 import pytest
 
 from shodan.contracts import InjectorKey, ShodanContractId
+from shodan.models.normalize_input_data import (
+    AssetsType,
+    CriticalPortsAndExposedAdminInterface,
+    NormalizeInputData,
+    TargetsType,
+)
 from shodan.services.client_api import ShodanClientAPI
 
 # --------
@@ -117,8 +123,8 @@ def test_critical_ports_with_valid_port_and_hostname_and_organization(
     user_info_response,
 ):
     """Scenario Outline: Execute Critical Ports with valid port, hostname and organization."""
-    # Given: A Critical Ports inject_content with valid port, hostname and organization
-    inject_content = _given_critical_ports_inject_content(
+    # Given: A Critical Ports inject_content with valid port, hostname and organization wrapped in NormalizeInputData
+    normalize_input_data = _given_critical_ports_normalize_input_data(
         port=port,
         hostname=hostname,
         organization=organization,
@@ -127,7 +133,7 @@ def test_critical_ports_with_valid_port_and_hostname_and_organization(
     # When: I execute the Critical Ports contract via process_shodan_search
     results, credit_user = _when_execute_critical_ports(
         shodan_client_api,
-        inject_content,
+        normalize_input_data=normalize_input_data,
         mock_search_responses=search_responses,
         mock_user_info=user_info_response,
     )
@@ -147,31 +153,57 @@ def test_critical_ports_with_valid_port_and_hostname_and_organization(
 # --------
 
 
-def _given_critical_ports_inject_content(
-    port: str,
+def _given_critical_ports_normalize_input_data(
+    port: str | list[str],
     hostname: str,
     organization: str,
 ) -> dict:
-    """Create inject_content as received from the real injection payload.
+    """Create NormalizeInputData for the Critical Ports contract.
 
-    Mirrors the structure from _shodan_execution in openaev_shodan.py:
-    data["injection"]["inject_content"]
+    Mirrors the structure produced by the real injection pipeline,
+    but wrapped inside NormalizeInputData as expected by process_shodan_search.
+
+    In manual mode:
+        - Targets are resolved from inject_content.hostname.
+        - TargetsType fields are not used for hostname resolution.
 
     Args:
         port: The port to search for.
         hostname: The hostname to search for.
-        organization: The organization to filter by.
+        organization: The organization filter. Can be empty.
+            If empty, use the hostname as the organization filter.
 
     Returns:
-        Dictionary matching the real inject_content structure.
+        A fully constructed NormalizeInputData instance ready to be
+        passed to process_shodan_search in tests.
 
     """
-    return {
-        InjectorKey.TARGET_SELECTOR_KEY: "manual",
-        "port": port,
-        "hostname": hostname,
-        "organization": organization,
-    }
+    inject_content = CriticalPortsAndExposedAdminInterface(
+        contract="critical_ports_and_exposed_admin_interface",
+        expectations=[],
+        target_selector="manual",
+        target_property_selector="automatic",
+        auto_create_assets=False,
+        port=port,
+        hostname=hostname,
+        organization=organization,
+    )
+
+    targets = TargetsType(
+        selector_key="manual",
+        asset_ids=[],
+        hostnames=[],
+        ips=[],
+        seen_ips=[],
+        assets=[],
+    )
+
+    return NormalizeInputData(
+        contract_name="critical_ports_and_exposed_admin_interface",
+        contract_id="test_contract_id",
+        inject_content=inject_content,
+        targets=targets,
+    )
 
 
 # --------
@@ -181,7 +213,7 @@ def _given_critical_ports_inject_content(
 
 def _when_execute_critical_ports(
     client: ShodanClientAPI,
-    inject_content: dict,
+    normalize_input_data: NormalizeInputData,
     mock_search_responses: list[dict],
     mock_user_info: dict,
 ) -> tuple:
@@ -193,7 +225,7 @@ def _when_execute_critical_ports(
 
     Args:
         client: The ShodanClientAPI instance.
-        inject_content: The inject content with hostname and organization.
+        normalize_input_data: The NormalizeInputData object passed to process_shodan_search.
         mock_search_responses: List of mocked search API responses, one per target.
         mock_user_info: The mocked user info API response.
 
@@ -212,10 +244,7 @@ def _when_execute_critical_ports(
         return response
 
     with patch.object(client, "_request_data", side_effect=mock_request_data):
-        return client.process_shodan_search(
-            contract_id=ShodanContractId.CRITICAL_PORTS_AND_EXPOSED_ADMIN_INTERFACE,
-            inject_content=inject_content,
-        )
+        return client.process_shodan_search(normalize_input_data=normalize_input_data)
 
 
 # --------

--- a/shodan/tests/shodan_contracts/cve_enumeration/test_cve_enumeration.py
+++ b/shodan/tests/shodan_contracts/cve_enumeration/test_cve_enumeration.py
@@ -4,9 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from shodan.contracts import InjectorKey, ShodanContractId
 from shodan.models.normalize_input_data import (
-    AssetsType,
     CVEEnumeration,
     NormalizeInputData,
     TargetsType,

--- a/shodan/tests/shodan_contracts/cve_specific_watchlist/test_cve_specific_watchlist.py
+++ b/shodan/tests/shodan_contracts/cve_specific_watchlist/test_cve_specific_watchlist.py
@@ -4,9 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from shodan.contracts import InjectorKey, ShodanContractId
 from shodan.models.normalize_input_data import (
-    AssetsType,
     CVESpecificWatchlist,
     NormalizeInputData,
     TargetsType,

--- a/shodan/tests/shodan_contracts/domain_discovery/test_domain_discovery.py
+++ b/shodan/tests/shodan_contracts/domain_discovery/test_domain_discovery.py
@@ -4,9 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from shodan.contracts import InjectorKey, ShodanContractId
 from shodan.models.normalize_input_data import (
-    AssetsType,
     DomainDiscovery,
     NormalizeInputData,
     TargetsType,

--- a/shodan/tests/shodan_contracts/domain_discovery/test_domain_discovery.py
+++ b/shodan/tests/shodan_contracts/domain_discovery/test_domain_discovery.py
@@ -5,6 +5,12 @@ from unittest.mock import patch
 import pytest
 
 from shodan.contracts import InjectorKey, ShodanContractId
+from shodan.models.normalize_input_data import (
+    AssetsType,
+    DomainDiscovery,
+    NormalizeInputData,
+    TargetsType,
+)
 from shodan.services.client_api import ShodanClientAPI
 
 # --------
@@ -151,8 +157,9 @@ def test_domain_discovery_with_valid_hostname_and_organization(
     user_info_response,
 ):
     """Scenario Outline: Execute domain discovery with valid hostname and organization."""
-    # Given: A domain discovery inject_content with valid hostname and organization
-    inject_content = _given_domain_discovery_inject_content(
+    # Given: A domain discovery inject_content with valid hostname
+    # and organization wrapped in NormalizeInputData
+    normalize_input_data = _given_domain_discovery_normalize_input_data(
         hostname=hostname,
         organization=organization,
     )
@@ -160,7 +167,7 @@ def test_domain_discovery_with_valid_hostname_and_organization(
     # When: I execute the domain discovery contract via process_shodan_search
     results, credit_user = _when_execute_domain_discovery(
         shodan_client_api,
-        inject_content,
+        normalize_input_data,
         mock_search_responses=search_responses,
         mock_user_info=user_info_response,
     )
@@ -180,28 +187,54 @@ def test_domain_discovery_with_valid_hostname_and_organization(
 # --------
 
 
-def _given_domain_discovery_inject_content(
+def _given_domain_discovery_normalize_input_data(
     hostname: str,
     organization: str,
-) -> dict:
-    """Create inject_content as received from the real injection payload.
+) -> NormalizeInputData:
+    """Create NormalizeInputData for the Domain Discovery contract.
 
-    Mirrors the structure from _shodan_execution in openaev_shodan.py:
-    data["injection"]["inject_content"]
+    Mirrors the structure produced by the real injection pipeline,
+    but wrapped inside NormalizeInputData as expected by process_shodan_search.
+
+    In manual mode:
+        - Targets are resolved from inject_content.hostname.
+        - TargetsType fields are not used for hostname resolution.
 
     Args:
-        hostname: The hostname to search for.
-        organization: The organization to filter by.
+        hostname: The hostname(s) to search for.
+        organization: The organization filter. Can be empty.
+            If empty, use the hostname as the organization filter.
 
     Returns:
-        Dictionary matching the real inject_content structure.
+        A fully constructed NormalizeInputData instance ready to be
+        passed to process_shodan_search in tests.
 
     """
-    return {
-        InjectorKey.TARGET_SELECTOR_KEY: "manual",
-        "hostname": hostname,
-        "organization": organization,
-    }
+    inject_content = DomainDiscovery(
+        contract="domain_discovery",
+        expectations=[],
+        target_selector="manual",
+        target_property_selector="automatic",
+        auto_create_assets=False,
+        hostname=hostname,
+        organization=organization,
+    )
+
+    targets = TargetsType(
+        selector_key="manual",
+        asset_ids=[],
+        hostnames=[],
+        ips=[],
+        seen_ips=[],
+        assets=[],
+    )
+
+    return NormalizeInputData(
+        contract_name="domain_discovery",
+        contract_id="test_contract_id",
+        inject_content=inject_content,
+        targets=targets,
+    )
 
 
 # --------
@@ -211,7 +244,7 @@ def _given_domain_discovery_inject_content(
 
 def _when_execute_domain_discovery(
     client: ShodanClientAPI,
-    inject_content: dict,
+    normalize_input_data: NormalizeInputData,
     mock_search_responses: list[dict],
     mock_user_info: dict,
 ) -> tuple:
@@ -223,7 +256,7 @@ def _when_execute_domain_discovery(
 
     Args:
         client: The ShodanClientAPI instance.
-        inject_content: The inject content with hostname and organization.
+        normalize_input_data: The NormalizeInputData object passed to process_shodan_search.
         mock_search_responses: List of mocked search API responses, one per target.
         mock_user_info: The mocked user info API response.
 
@@ -242,10 +275,7 @@ def _when_execute_domain_discovery(
         return response
 
     with patch.object(client, "_request_data", side_effect=mock_request_data):
-        return client.process_shodan_search(
-            contract_id=ShodanContractId.DOMAIN_DISCOVERY,
-            inject_content=inject_content,
-        )
+        return client.process_shodan_search(normalize_input_data=normalize_input_data)
 
 
 # --------

--- a/shodan/tests/shodan_contracts/ip_enumeration/test_ip_enumeration.py
+++ b/shodan/tests/shodan_contracts/ip_enumeration/test_ip_enumeration.py
@@ -4,9 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from shodan.contracts import InjectorKey, ShodanContractId
 from shodan.models.normalize_input_data import (
-    AssetsType,
     IPEnumeration,
     NormalizeInputData,
     TargetsType,

--- a/shodan/tests/shodan_contracts/ip_enumeration/test_ip_enumeration.py
+++ b/shodan/tests/shodan_contracts/ip_enumeration/test_ip_enumeration.py
@@ -5,6 +5,12 @@ from unittest.mock import patch
 import pytest
 
 from shodan.contracts import InjectorKey, ShodanContractId
+from shodan.models.normalize_input_data import (
+    AssetsType,
+    IPEnumeration,
+    NormalizeInputData,
+    TargetsType,
+)
 from shodan.services.client_api import ShodanClientAPI
 
 # --------
@@ -94,15 +100,15 @@ def test_ip_enumeration_with_valid_ip_address(
     user_info_response,
 ):
     """Scenario Outline: Execute IP Enumeration with valid IP address"""
-    # Given: A IP Enumeration inject_content with valid IP address
-    inject_content = _given_ip_enumeration_inject_content(
+    # Given: A IP Enumeration inject_content with valid ip_address wrapped in NormalizeInputData
+    normalize_input_data = _given_ip_enumeration_normalize_input_data(
         ip_address=ip_address,
     )
 
     # When: I execute the IP Enumeration contract via process_shodan_search
     results, credit_user = _when_execute_ip_enumeration(
         shodan_client_api,
-        inject_content,
+        normalize_input_data=normalize_input_data,
         mock_search_responses=search_responses,
         mock_user_info=user_info_response,
     )
@@ -122,25 +128,50 @@ def test_ip_enumeration_with_valid_ip_address(
 # --------
 
 
-def _given_ip_enumeration_inject_content(
+def _given_ip_enumeration_normalize_input_data(
     ip_address: str,
-) -> dict:
-    """Create inject_content as received from the real injection payload.
+) -> NormalizeInputData:
+    """Create NormalizeInputData for the IP Enumeration contract.
 
-    Mirrors the structure from _shodan_execution in openaev_shodan.py:
-    data["injection"]["inject_content"]
+    Mirrors the structure produced by the real injection pipeline,
+    but wrapped inside NormalizeInputData as expected by process_shodan_search.
+
+    In manual mode:
+        - Targets are resolved from inject_content.ip.
+        - TargetsType fields are not used for ip resolution.
 
     Args:
-        ip_address: The IP address to search for.
+        ip_address: The ip(s) to search for.
 
     Returns:
-        Dictionary matching the real inject_content structure.
+        A fully constructed NormalizeInputData instance ready to be
+        passed to process_shodan_search in tests.
 
     """
-    return {
-        InjectorKey.TARGET_SELECTOR_KEY: "manual",
-        "ip": ip_address,
-    }
+    inject_content = IPEnumeration(
+        contract="ip_enumeration",
+        expectations=[],
+        target_selector="manual",
+        target_property_selector="automatic",
+        auto_create_assets=False,
+        ip=ip_address,
+    )
+
+    targets = TargetsType(
+        selector_key="manual",
+        asset_ids=[],
+        hostnames=[],
+        ips=[],
+        seen_ips=[],
+        assets=[],
+    )
+
+    return NormalizeInputData(
+        contract_name="ip_enumeration",
+        contract_id="test_contract_id",
+        inject_content=inject_content,
+        targets=targets,
+    )
 
 
 # --------
@@ -150,7 +181,7 @@ def _given_ip_enumeration_inject_content(
 
 def _when_execute_ip_enumeration(
     client: ShodanClientAPI,
-    inject_content: dict,
+    normalize_input_data: NormalizeInputData,
     mock_search_responses: list[dict],
     mock_user_info: dict,
 ) -> tuple:
@@ -162,7 +193,7 @@ def _when_execute_ip_enumeration(
 
     Args:
         client: The ShodanClientAPI instance.
-        inject_content: The inject content with IP address.
+        normalize_input_data: The NormalizeInputData object passed to process_shodan_search.
         mock_search_responses: List of mocked search API responses, one per target.
         mock_user_info: The mocked user info API response.
 
@@ -181,10 +212,7 @@ def _when_execute_ip_enumeration(
         return response
 
     with patch.object(client, "_request_data", side_effect=mock_request_data):
-        return client.process_shodan_search(
-            contract_id=ShodanContractId.IP_ENUMERATION,
-            inject_content=inject_content,
-        )
+        return client.process_shodan_search(normalize_input_data=normalize_input_data)
 
 
 # --------


### PR DESCRIPTION
### Proposed changes

* Added `assets` and `asset-groups` management
* Creation of a normalization model for entry points (`inject_content` and `targets`)
* `client_api.py` adjustments and refactoring 
* `Contracts` adjustments and refactoring 
   - For some contracts, fields had to be present in the UI for `assets` and `asset-groups`.
   - Fix Data mapping for the `cve_specific_watchlist` contract
   - Visual adjustment of output trace messages
* Tests update

### Related issues

* Closes #149

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...-->