### PR TITLE
[ci] fix(aws): fix pip version to 25.0.1 (#178)

### DIFF
--- a/aws/Dockerfile
+++ b/aws/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.13-alpine AS builder
 
+ENV PIP_VERSION=25.0.1
+
 RUN apk update && apk upgrade && apk add git
 
 WORKDIR /opt/injector_common
@@ -7,6 +9,8 @@ COPY --from=injector_common ./ ./
 
 WORKDIR /
 RUN git clone https://github.com/OpenAEV-Platform/client-python
+
+RUN pip3 install --upgrade pip==${PIP_VERSION}
 
 # poetry version available on Ubuntu 24.04
 RUN pip3 install poetry==2.3.2 \
@@ -34,6 +38,7 @@ ARG PYOAEV_GIT_BRANCH_OVERRIDE
 RUN if [[ ${PYOAEV_GIT_BRANCH_OVERRIDE} ]] ; then \
         echo "Forcing specific version of client-python" && \
         apk add --no-cache git && \
+        pip install --upgrade pip==${PIP_VERSION} && \
         pip install pip3-autoremove && \
         pip-autoremove pyoaev -y && \
         pip install git+https://github.com/OpenAEV-Platform/client-python@${PYOAEV_GIT_BRANCH_OVERRIDE} ; \


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix pip version to 25.0.1

The `pacu` dependency works only for pip < 25.1. As it's a proprietary code, we can't a fix to their repo so we can only fix our current version for now. Since the CI uses pip 25.3, it has to downgrade pip when doing `poetry install`. This causes caching issues between the two versions.

### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Closes #178
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...-->