### PR TITLE
[ci] ci(tests): add GitHub Actions workflow for injector tests (#191)

### DIFF
--- a/.github/workflows/test-injectors.yml
+++ b/.github/workflows/test-injectors.yml
@@ -1,0 +1,62 @@
+name: "Test Injectors"
+
+on:
+  push:
+    branches:
+      - main
+      - "release/**"
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]*"
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        injector_name: ["nuclei", "nmap", "http-query"]
+    name: "Test ${{ matrix.injector_name }}"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Clone pyoaev # this is only to satisfy poetry; not used
+        run: |
+          if [ "$GITHUB_REF_NAME" = "main" ]; then
+            CLONE_BRANCH="main"
+          else
+            CLONE_BRANCH="release/current"
+          fi
+          git clone -b "$CLONE_BRANCH" https://github.com/OpenAEV-Platform/client-python "$GITHUB_WORKSPACE/../client-python"
+
+      - name: Install poetry
+        run: pip install poetry==2.3.2 && poetry config installer.re-resolve false
+
+      - name: Run injector tests
+        working-directory: ${{ matrix.injector_name }}
+        run: |
+          if [ "$GITHUB_REF_NAME" = "main" ] || [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            PYOAEV_REF="main"
+          else
+            PYOAEV_REF="release/current"
+          fi
+
+          echo "Running tests for injector: ${{ matrix.injector_name }}"
+          poetry install
+          poetry run pip install --force-reinstall git+https://github.com/OpenAEV-Platform/client-python.git@${PYOAEV_REF}
+          poetry run pip install coverage
+          poetry run coverage run -m unittest
+          poetry run coverage xml -o coverage.xml
+          
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: connectors
+          fail_ci_if_error: false
+          verbose: true


### PR DESCRIPTION
### Proposed changes

* Add `.github/workflows/test-injectors.yml` — a GitHub Actions workflow that runs unit tests for `nuclei`, `nmap`, and `http-query` injectors in a matrix build
* Uses Python 3.13 and Poetry for dependency management, mirroring the CircleCI test setup
* Dynamically selects the `pyoaev` branch (`main` or `release/current`) based on the Git ref, matching existing CI behaviour
* Generates per-injector coverage reports and uploads them to Codecov (non-blocking on failure)

### Testing Instructions

1. Open a PR — the "Test Injectors" workflow should trigger automatically
2. Verify all three matrix jobs (`nuclei`, `nmap`, `http-query`) pass
3. Check Codecov for coverage report uploads

### Related issues

* Closes #191

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments

The workflow clones the `client-python` repo to satisfy Poetry's dependency resolution, then force-reinstalls the correct `pyoaev` ref — identical to what CircleCI does today.