### PR TITLE
[ci] refactor: dynamic test matrix with per-injector ci pipeline (#196)

### DIFF
--- a/.github/scripts/build_test_matrix.py
+++ b/.github/scripts/build_test_matrix.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Generate the GitHub Actions test matrix for injector tests.
+
+Discovers all injectors with test directories (test/ or tests/) and
+includes them in the matrix. All injectors are always tested.
+"""
+
+import json
+import os
+from pathlib import Path
+
+# Directories that are NOT injectors (excluded from discovery)
+EXCLUDED_DIRS = {
+    ".circleci",
+    ".github",
+    "scripts",
+    ".git",
+    "__pycache__",
+    "node_modules",
+}
+
+
+def discover_injectors() -> list[str]:
+    """Find all injector directories that contain test/ or tests/ subdirectories."""
+    injectors = []
+    for entry in sorted(Path(".").iterdir()):
+        if (
+            not entry.is_dir()
+            or entry.name.startswith(".")
+            or entry.name in EXCLUDED_DIRS
+        ):
+            continue
+        if (entry / "test").is_dir() or (entry / "tests").is_dir():
+            injectors.append(entry.name)
+    return injectors
+
+
+def write_output(key: str, value: str) -> None:
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    line = f"{key}={value}\n"
+    if output_file:
+        with Path(output_file).open("a") as f:
+            f.write(line)
+    else:
+        print(line, end="")
+
+
+def main() -> None:
+    all_injectors = discover_injectors()
+    print(f"Total injectors with tests: {len(all_injectors)}")
+
+    for i in all_injectors:
+        print(f"  - {i}")
+
+    if not all_injectors:
+        print("No injectors to test.")
+        write_output("has_tests", "false")
+        write_output("matrix", json.dumps({"include": []}, separators=(",", ":")))
+        return
+
+    entries = [{"name": i, "injector": i} for i in all_injectors]
+    write_output("has_tests", "true")
+    write_output("matrix", json.dumps({"include": entries}, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/test-injectors.yml
+++ b/.github/workflows/test-injectors.yml
@@ -9,54 +9,74 @@ on:
       - "[0-9]+.[0-9]+.[0-9]*"
   pull_request:
 
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
+  detect-test-files:
+    name: Detect test files
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has_tests: ${{ steps.set-matrix.outputs.has_tests }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: set-matrix
+        name: Build test matrix
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          RELEASE_REF: main
+        run: python .github/scripts/build_test_matrix.py
+
   test:
+    name: "Test ${{ matrix.name }}"
+    needs: detect-test-files
+    if: needs.detect-test-files.outputs.has_tests == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        injector_name: ["nuclei", "nmap", "http-query"]
-    name: "Test ${{ matrix.injector_name }}"
+      matrix: ${{ fromJson(needs.detect-test-files.outputs.matrix) }}
+
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
-      - name: Clone pyoaev # this is only to satisfy poetry; not used
+      - name: Clone pyoaev (satisfies Poetry path dependency)
+        working-directory: ..
         run: |
-          if [ "$GITHUB_REF_NAME" = "main" ]; then
-            CLONE_BRANCH="main"
+          BRANCH="${{ github.head_ref || github.ref_name }}"
+          if [ "$BRANCH" = "main" ]; then
+            git clone -b main https://github.com/OpenAEV-Platform/client-python
           else
-            CLONE_BRANCH="release/current"
+            git clone -b release/current https://github.com/OpenAEV-Platform/client-python
           fi
-          git clone -b "$CLONE_BRANCH" https://github.com/OpenAEV-Platform/client-python "$GITHUB_WORKSPACE/../client-python"
 
       - name: Install poetry
         run: pip install poetry==2.3.2 && poetry config installer.re-resolve false
 
-      - name: Run injector tests
-        working-directory: ${{ matrix.injector_name }}
-        run: |
-          if [ "$GITHUB_REF_NAME" = "main" ] || [ "$GITHUB_REF_TYPE" = "tag" ]; then
-            PYOAEV_REF="main"
-          else
-            PYOAEV_REF="release/current"
-          fi
+      - name: Run tests via run_test.sh
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          RELEASE_REF: main
+        run: bash run_test.sh ${{ matrix.injector }}
 
-          echo "Running tests for injector: ${{ matrix.injector_name }}"
-          poetry install
-          poetry run pip install --force-reinstall git+https://github.com/OpenAEV-Platform/client-python.git@${PYOAEV_REF}
-          poetry run pip install coverage
-          poetry run coverage run -m unittest
-          poetry run coverage xml -o coverage.xml
-          
       - name: Upload coverage to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && hashFiles(format('{0}/coverage.xml', matrix.injector)) != '' }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: connectors
+          root_dir: ${{ github.workspace }}
           fail_ci_if_error: false
           verbose: true

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+# Common test script for all OpenAEV injectors.
+# Usage:
+#   ./run_test.sh <injector_dir>          Run tests for a single injector
+#   ./run_test.sh <dir1> <dir2> ...        Run tests for multiple injectors
+#   ./run_test.sh                           Auto-discover and run all injector tests
+#
+# Environment variables:
+#   RELEASE_REF       Base branch for git diff (default: main)
+#   GITHUB_REF_NAME   Current branch name (GitHub Actions)
+#   CIRCLE_BRANCH     Current branch name (CircleCI)
+
+set -e
+
+RELEASE_REF="${RELEASE_REF:-main}"
+BRANCH="${CIRCLE_BRANCH:-${GITHUB_REF_NAME:-$RELEASE_REF}}"
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+# Determine pyoaev git branch
+if [ "$BRANCH" = "main" ]; then
+  PYOAEV_BRANCH="main"
+else
+  PYOAEV_BRANCH="release/current"
+fi
+
+# Discover injectors with test directories
+discover_injectors() {
+  find "$REPO_ROOT" -maxdepth 2 \( -name "test" -o -name "tests" \) -type d \
+    | sed "s|^$REPO_ROOT/||; s|/test.*||" \
+    | sort -u
+}
+
+# Check whether a pyproject.toml uses poetry as its build backend
+uses_poetry() {
+  local pyproject="$1/pyproject.toml"
+  [ -f "$pyproject" ] && grep -q 'poetry' "$pyproject" 2>/dev/null
+}
+
+# Detect install arguments for a project's pyproject.toml
+get_install_args() {
+  local pyproject="$1/pyproject.toml"
+  local args=""
+
+  # Check for poetry group "test" containing test deps
+  if grep -q '\[tool\.poetry\.group\.test' "$pyproject" 2>/dev/null; then
+    args="$args --with test"
+  # Check if dev optional-dependencies contain pytest
+  elif sed -n '/\[project\.optional-dependencies\]/,/^\[/p' "$pyproject" 2>/dev/null | grep -q 'pytest'; then
+    args="$args --extras dev"
+  # Check if poetry dev group contains pytest
+  elif grep -q '\[tool\.poetry\.group\.dev' "$pyproject" 2>/dev/null; then
+    if sed -n '/\[tool\.poetry\.group\.dev/,/^\[/p' "$pyproject" | grep -q 'pytest'; then
+      args="$args --with dev"
+    fi
+  fi
+
+  echo "$args"
+}
+
+# Detect whether the injector uses pytest or unittest
+uses_pytest() {
+  local injector_dir="$1"
+  local pyproject="$injector_dir/pyproject.toml"
+
+  if grep -q '\[tool\.pytest' "$pyproject" 2>/dev/null; then
+    return 0
+  fi
+
+  if [ -f "$injector_dir/tests/conftest.py" ] || [ -f "$injector_dir/test/conftest.py" ]; then
+    return 0
+  fi
+
+  if grep -q 'pytest' "$pyproject" 2>/dev/null; then
+    return 0
+  fi
+
+  return 1
+}
+
+# Detect test directory
+detect_test_dir() {
+  local injector_dir="$1"
+  if [ -d "$injector_dir/test" ]; then
+    echo "test"
+  elif [ -d "$injector_dir/tests" ]; then
+    echo "tests"
+  fi
+}
+
+# Run tests for a single injector
+run_injector_tests() {
+  local injector="$1"
+  local injector_dir="$REPO_ROOT/$injector"
+
+  echo "==========================================="
+  echo "Processing: $injector"
+  echo "==========================================="
+
+  cd "$injector_dir"
+
+  local test_dir
+  test_dir=$(detect_test_dir "$injector_dir")
+
+  if uses_poetry "$injector_dir"; then
+    echo "🔄 Running tests for $injector (poetry)"
+
+    command -v poetry >/dev/null 2>&1 || pip install -q poetry==2.3.2
+    poetry config installer.re-resolve false 2>/dev/null || true
+
+    echo "→ poetry install"
+    local install_args
+    install_args=$(get_install_args "$injector_dir")
+    poetry install $install_args
+
+    echo "→ Installing pyoaev from branch $PYOAEV_BRANCH"
+    poetry run pip install --force-reinstall -q \
+      "git+https://github.com/OpenAEV-Platform/client-python.git@$PYOAEV_BRANCH"
+
+    poetry run pip install -q coverage
+
+    local test_rc=0
+    if uses_pytest "$injector_dir"; then
+      echo "→ Running pytest"
+      poetry run python -m coverage run -m pytest -q -rA || test_rc=$?
+    else
+      echo "→ Running unittest"
+      poetry run python -m coverage run -m unittest discover -s "$test_dir" -v || test_rc=$?
+    fi
+
+    poetry run python -m coverage xml -o coverage.xml || true
+
+  else
+    echo "🔄 Running tests for $injector (setuptools)"
+
+    pip install -q -e .
+
+    echo "→ Installing pyoaev from branch $PYOAEV_BRANCH"
+    pip install --force-reinstall -q \
+      "git+https://github.com/OpenAEV-Platform/client-python.git@$PYOAEV_BRANCH"
+
+    pip install -q coverage
+
+    local test_rc=0
+    if uses_pytest "$injector_dir"; then
+      echo "→ Running pytest"
+      python -m coverage run -m pytest -q -rA || test_rc=$?
+    else
+      echo "→ Running unittest"
+      python -m coverage run -m unittest discover -s "$test_dir" -v || test_rc=$?
+    fi
+
+    python -m coverage xml -o coverage.xml || true
+  fi
+
+  cd "$REPO_ROOT"
+  return $test_rc
+}
+
+# --- Main ---
+
+if [ $# -gt 0 ]; then
+  injectors="$*"
+else
+  injectors=$(discover_injectors)
+fi
+
+exit_code=0
+for injector in $injectors; do
+  if run_injector_tests "$injector"; then
+    echo "✅ $injector tests passed"
+  else
+    echo "❌ $injector tests FAILED"
+    exit_code=1
+  fi
+done
+
+exit $exit_code


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

- Add `.github/scripts/build_test_matrix.py` to auto-discover injectors with `test/` or `tests/` directories
- Add `run_test.sh` universal test runner supporting both poetry and setuptools projects, pytest/unittest auto-detection, conditional install args, pyoaev branch override, and coverage output
- Update test-injectors.yml to use a 2-job workflow: `detect-test-files` builds the matrix dynamically, then `test` jobs run in parallel
- Matrix now discovers 5 injectors (http-query, injector_common, nmap, nuclei, shodan) instead of hardcoded 3

### Related issues

* Closes #196 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->