### PR TITLE
[injectors] ci(build): bump requests to ~=2.33.1 for pyoaev (#215)

### DIFF
--- a/shodan/pyproject.toml
+++ b/shodan/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "injector_common @ ../injector_common",
     "pydantic~=2.11.7",
     "pydantic-settings~=2.11.0",
-    "requests~=2.32.5",
+    "requests~=2.33.1",
     "limiter==0.5.0",
     "tenacity~=9.1.2",
     "rich~=14.2.0",

--- a/teams/pyproject.toml
+++ b/teams/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.11,<4.0"
 dependencies = [
     "pyoaev (==2.3.4); extra != 'dev'",
     "injector_common @ ../injector_common",
-    "requests~=2.32.3",
+    "requests~=2.33.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Proposed changes

* Bump `requests` from ~=2.32.x to ~=2.33.1 in `shodan/pyproject.toml` and `teams/pyproject.toml`
* Aligns with pyoaev 2.3.4 which requires `requests >=2.33.1,<2.34.0`

### Testing Instructions

1. Run `pip install -e .` in `shodan/` and `teams/` — should resolve without conflicts
2. Verify injectors start normally

### Related issues

* Closes #215

### Checklist

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments
Dependency-only change, no code logic modified.