### PR TITLE
[injectors] ci(build): relax requests pin for pyoaev compatibility (#215)

### DIFF
--- a/shodan/pyproject.toml
+++ b/shodan/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "injector_common @ ../injector_common",
     "pydantic~=2.11.7",
     "pydantic-settings~=2.11.0",
-    "requests~=2.32.5",
+    "requests~=2.32",
     "limiter==0.5.0",
     "tenacity~=9.1.2",
     "rich~=14.2.0",

--- a/teams/pyproject.toml
+++ b/teams/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.11,<4.0"
 dependencies = [
     "pyoaev (==2.3.4); extra != 'dev'",
     "injector_common @ ../injector_common",
-    "requests~=2.32.3",
+    "requests~=2.32",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Proposed changes

* Change `requests~=2.32.5` / `requests~=2.32.3` → `requests~=2.32` in shodan and teams
* Keeps compatible-release upper bound (`<2.33.0`) while allowing any `2.32.x` patch so poetry can resolve against both:
  - **PyPI pyoaev 2.3.4** (requires `requests >=2.32.3,<2.33.0`) — used in tests
  - **Git client-python main** (requires `requests >=2.33.1,<2.34.0`) — used in Docker builds

### Testing Instructions

1. `run_test.sh shodan` / `run_test.sh teams` should pass (poetry resolves requests <2.33.0 via PyPI pyoaev)
2. Docker build should pass (poetry resolves requests >=2.33.1 via git pyoaev)

### Related issues

* Closes #215

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

### Further comments

The root cause: pyoaev on PyPI pins `requests <2.33.0` but the git main branch pins `>=2.33.1`. A tight `~=2.32.x` constraint on a specific patch in the injectors is unnecessarily restrictive. Using `~=2.32` (equivalent to `>=2.32,<2.33.0`) keeps compatibility with both pyoaev sources while still capping at the minor version.