### PR TITLE
[netexec] ci(netexec): add netexec to CI test, build and deploy (#218)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,14 +231,14 @@ workflows:
       - test:
           matrix:
             parameters:
-              injector_name: ["nuclei", "nmap", "http-query"]
+              injector_name: ["netexec", "nuclei", "nmap", "http-query"]
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*/
       - build_docker_images:
           matrix:
             parameters:
-              injector_name: [ "aws", "http-query", "nmap", "nuclei", "shodan", "teams" ]
+              injector_name: [ "aws", "http-query", "netexec", "nmap", "nuclei", "shodan", "teams" ]
           requires:
             - ensure_formatting
             - linter
@@ -249,7 +249,7 @@ workflows:
       - publish_images:
           matrix:
             parameters:
-              injector_name: [ "aws", "http-query", "nmap", "nuclei", "shodan", "teams" ]
+              injector_name: [ "aws", "http-query", "netexec", "nmap", "nuclei", "shodan", "teams" ]
           requires:
             - build_docker_images
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,14 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
+      - run:
+          working_directory: ~/openaev/<< parameters.injector_name >>
+          name: Check if injector exists
+          command: |
+            if [ ! -f pyproject.toml ]; then
+              echo "pyproject.toml not found, injector may not exist on this branch"
+              circleci-agent step halt
+            fi;
       - run: # this is only to satisfy poetry; not used
           working_directory: ~/
           name: Clone pyoaev
@@ -87,6 +95,14 @@ jobs:
         type: string
     steps:
       - checkout
+      - run:
+          working_directory: ~/openaev/<< parameters.injector_name >>
+          name: Check if injector exists
+          command: |
+            if [ ! -f pyproject.toml ]; then
+              echo "pyproject.toml not found, injector may not exist on this branch"
+              circleci-agent step halt
+            fi;
       - run:
           working_directory: ~/openaev
           name: Set semantic version environment
@@ -138,6 +154,14 @@ jobs:
         type: string
     steps:
       - checkout
+      - run:
+          working_directory: ~/openaev/<< parameters.injector_name >>
+          name: Check if injector exists
+          command: |
+            if [ ! -f pyproject.toml ]; then
+              echo "pyproject.toml not found, injector may not exist on this branch"
+              circleci-agent step halt
+            fi;
       - run:
           working_directory: ~/openaev
           name: Set semantic version environment
@@ -231,7 +255,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              injector_name: ["netexec", "nuclei", "nmap", "http-query"]
+              injector_name: ["http-query", "netexec", "nmap", "nuclei"]
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*/


### PR DESCRIPTION
### Proposed changes

* Adding netexec to the following CI steps: `test`, `build_docker_images`, `publish_images`
* Adding a skip when an injector is not detected (due to the differences between `main` and `release/current`)

### Testing Instructions

1. Run pipeline on CircleCI

### Related issues

* Closes #218 

### Checklist

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

As of now (2026-29-04-13-14), `netexec` exists on `release/current` but not in `main`