### PR TITLE
chore(renovate): emit Conventional Commits titles (#253)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    ":semanticCommits",
     "config:recommended"
   ],
   "labels": [
@@ -9,7 +10,6 @@
   ],
   "prConcurrentLimit": 2,
   "baseBranches": ["main"],
-  "commitMessagePrefix": "[tool] chore(deps):",
   "packageRules": [
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
## Summary

Renovate now emits Conventional Commits titles (`chore(deps): ...`) instead of the old `[deps]` bracket prefix.

Closes #253