### PR TITLE
chore: audit & align issue templates (#257)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # pyoaev
 config.yml
+!.github/ISSUE_TEMPLATE/config.yml
 exports
 logs
 __test__.py


### PR DESCRIPTION
Closes #257

## Summary
Audit and align the GitHub issue templates under `.github/ISSUE_TEMPLATE/` with the canonical Filigran templates.

- Added `config.yml` with `blank_issues_enabled: true` only (it was missing from this repo)
- Added a `.gitignore` negation (`!.github/ISSUE_TEMPLATE/config.yml`) so the broad `config.yml` ignore rule (used for injector runtime configs) no longer excludes the issue-template `config.yml`
- `bug_report.md`, `feature_request.md`, `question.md` verified consistent with the canonical templates (names, about, titles, labels, types)
- No security `contact_link` (native private vulnerability reporting is enabled on this public repo) and no `Filigran community Slack` link