### PR TITLE
docs: clarify primary type labels are issues-only (PRs use ownership labels) (#263)

### DIFF
--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -22,9 +22,9 @@ type(scope?)!?: description (#issue)
 - `type` is one of: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`,
   `test`, `build`, `ci`, `revert`.
 - `scope` is optional — a **lowercase** noun in parentheses naming the affected
-  area. In this repository, use the **lowercase injector name** as the scope
-  (e.g. `feat(http-query):`, `fix(caldera):`). The scope **replaces** the old
-  `[injector]` bracket prefix, which is **discontinued**.
+  area, e.g. `feat(api):`, `fix(frontend):`, `docs(connectors):`. The scope
+  **replaces** the old `[backend]` / `[frontend]` / `[component]` bracket
+  prefixes, which are **discontinued**.
 - `!` is optional and marks a breaking change (e.g. `feat(api)!: ...`), optionally
   with a `BREAKING CHANGE:` footer.
 - `description` **starts with a lowercase letter** and has **no trailing period**.
@@ -48,9 +48,10 @@ chore(ci): migrate dependency management to uv (#1237)
 feat(api)!: remove deprecated v1 endpoints (#1238)
 ```
 
-## 2. Type label (one per issue)
+## 2. Type label (issues only — one per issue)
 
-The title `type` maps to a primary type label:
+The title `type` maps to a primary type label. **Primary type labels are applied
+to issues only:**
 
 | Title prefix | Type label      | Color  |
 |--------------|-----------------|--------|
@@ -58,10 +59,23 @@ The title `type` maps to a primary type label:
 | `fix:`       | `bug`           | red    |
 | `docs:`      | `documentation` | blue   |
 
+On issues, also set the GitHub **Type** field to match (`feat:` → `Feature`,
+`fix:` → `Bug`, every other type → `Task`).
+
 `chore:`, `style:`, `ci:`, `build:`, `perf:`, `refactor:`, `test:` and `revert:`
 are valid types; they do not each require a dedicated label (use a repository
 area/scope label where useful). `security` is a **label** (applied on top of the
 type, e.g. a `fix:` that closes a vulnerability), not a title type.
+
+> **Pull requests do NOT carry a primary type label.** A pull request's `type:`
+> title prefix (and its linked issue) already convey the type, so `feature`,
+> `bug` and `documentation` must **never** be added to a pull request — remove
+> them if they appear.
+>
+> Pull requests **do** still carry other labels. In particular, add an
+> **ownership** label — typically `filigran team` or `community` — so the source
+> of a contribution is clear at a glance. Area/scope labels and workflow labels
+> (e.g. `dependencies`, `do not merge`) also apply to pull requests where useful.
 
 ## 3. Workflow & ownership labels
 
@@ -98,7 +112,12 @@ taxonomy stands out consistently across every Filigran repository.
 
 - [ ] Title follows `type(scope?)!?: description` (lowercase, no trailing period)
 - [ ] Pull request titles end with the `(#issue)` reference
-- [ ] Exactly one primary type label matches the title prefix
+- [ ] **Issues only:** exactly one primary type label (`feature` / `bug` /
+      `documentation`) matches the title prefix, and the GitHub **Type** field
+      (Feature / Bug / Task) is set to match
+- [ ] **Pull requests:** no primary type label (the title prefix conveys the
+      type); add an ownership label (`filigran team` / `community`) and any useful
+      area labels
 - [ ] Area labels added where useful
 - [ ] No deprecated labels
 - [ ] Commits are signed and the PR is linked to an issue

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -17,13 +17,13 @@
 # ── Primary type labels (map to the Conventional Commits title prefix) ──
 - name: feature
   color: "6a3eef"
-  description: "Type: new feature or capability (feat:)."
+  description: "Type: new feature or capability (feat:). Issues only — not for PRs."
 - name: bug
   color: "d73a4a"
-  description: "Type: something isn't working (fix:)."
+  description: "Type: something isn't working (fix:). Issues only — not for PRs."
 - name: documentation
   color: "0075ca"
-  description: "Type: documentation only (docs:)."
+  description: "Type: documentation only (docs:). Issues only — not for PRs."
 - name: security
   color: "d93f0b"
   description: "Security vulnerability, hardening or guardrail."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,9 @@ in [`.github/LABELS.md`](.github/LABELS.md). In short:
   nouns. Types: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`,
   `test`, `build`, `ci`, `revert`.
 
-* **Integration name as scope** — Use the **lowercase injector name** as the
-  Conventional Commits scope (e.g. `feat(http-query): ...`, `fix(caldera): ...`).
-  The old `[injector]` bracket prefixes are **discontinued**.
+* **No more bracket prefixes** — The old `[backend]` / `[frontend]` /
+  `[component]` prefixes are **discontinued**; use a Conventional Commits scope
+  instead (e.g. `fix(backend): ...`).
 
 * **GitHub reference** — Pull request titles **must** end with the related issue
   reference, e.g. `(#1234)` (the PR title becomes the squash-merge commit). Every
@@ -47,9 +47,13 @@ in [`.github/LABELS.md`](.github/LABELS.md). In short:
 * **Signed commits** — All commits must be signed. See the
   [GitHub documentation on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
 
-* **Labels** — Every issue carries one primary type label matching its title
+* **Labels** — Every **issue** carries one primary type label matching its title
   prefix (`feature` for `feat:`, `bug` for `fix:`, `documentation` for `docs:`)
-  plus optional area labels. Do not use the deprecated `enhancement` /
+  plus optional area labels, and its GitHub **Type** (Feature / Bug / Task) set
+  to match. **Pull requests do not carry a primary type label** (the `type:`
+  title prefix already conveys the type), but they should carry an **ownership**
+  label — `filigran team` or `community` — to differentiate the author, plus any
+  useful area/scope labels. Do not use the deprecated `enhancement` /
   `feature request` labels — use `feature`. See
   [`.github/LABELS.md`](.github/LABELS.md) for the shared palette
   ([`.github/labels.yml`](.github/labels.yml)).


### PR DESCRIPTION
## Summary

Clarifies the shared label taxonomy so it can never be misread (by a human or an automated reviewer):

- **Primary type labels** (`feature` / `bug` / `documentation`) are applied to **issues only**, alongside the GitHub issue **Type**.
- **Pull requests do not carry a primary type label** — the `type:` title prefix conveys the type. PRs should instead carry an **ownership** label (`filigran team` / `community`) to differentiate the author, plus any useful area/workflow labels.

Updated `.github/LABELS.md`, `.github/labels.yml`, and the CONTRIBUTING conventions block.

Closes #263