### PR TITLE
docs: improve PR title format hint in PR template and CONTRIBUTING.md (#271)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,14 @@ Thank you very much for your pull request to the OpenAEV project! We as a commun
 driven project depend on support and contributions like this!
 
 Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
+
+PR TITLE FORMAT (enforced by CI):
+  type(scope?)!?: description (#123)
+  - type: feat | fix | chore | docs | style | refactor | perf | test | build | ci | revert
+  - scope: optional, e.g. injector name
+  - description: must start with a lowercase letter
+  - (#123): required linked issue number
+  Example: feat(http-request): add retry mechanism (#42)
 -->
 
 ### Proposed changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -498,12 +498,16 @@ This helps avoid duplicated work and ensures alignment with maintainers.
 | Documentation | `docs/<issue>-<description>`           | 
 | CI            | `ci/<issue>-<description>`             |
 
-**Commit message format**: This repository enforces a strict commit convention validated in CI.
+**Commit and PR title format**: This repository enforces a strict commit convention validated in CI.
 Format:
 ```
-# GitHub issue reference is mandatory
-<type>(<optional scope>): <description> (#<issue>)
+type(scope?)!?: description (#123)
 ```
+- **type**: one of `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `revert`
+- **scope**: optional — use the injector name or affected area
+- **description**: must start with a lowercase letter
+- **`(#123)`**: required — the linked issue number at the end
+- Examples: `feat(http-request): add retry mechanism (#42)`, `fix: resolve config loading issue (#99)`
 
 For more information, see [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 


### PR DESCRIPTION
## Summary

Port of the contributing documentation improvement from OpenCTI connectors (https://github.com/OpenCTI-Platform/connectors/commit/b3b61c0597951711e336a8caa4e126091187b7c1).

The CI already validates PR titles via `validate-pr-title.yml`, but contributors weren't given a clear reminder of the expected format. This PR surfaces it upfront.

## Changes

- **`.github/PULL_REQUEST_TEMPLATE.md`**: add PR title format block inside the opening comment so it's visible before the contributor clears the template
- **`CONTRIBUTING.md`**: expand the commit/PR title format section with a field-by-field breakdown and examples

Closes #271