### PR TITLE
fix(nuclei): minimising conflicts between config and env vars (#280)

### DIFF
--- a/nuclei/Dockerfile
+++ b/nuclei/Dockerfile
@@ -40,8 +40,8 @@ RUN if [[ ${PYOAEV_GIT_BRANCH_OVERRIDE} ]] ; then \
     fi
 
 # get nuclei from above
-ENV NUCLEI_VERSION=3.8.0
-ENV NUCLEI_URL=https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_amd64.zip
+ARG NUCLEI_VERSION=3.8.0
+ARG NUCLEI_URL=https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_amd64.zip
 ADD ${NUCLEI_URL} /tmp
 RUN unzip /tmp/nuclei_${NUCLEI_VERSION}_linux_amd64.zip -d /usr/local/bin/
 

--- a/nuclei/nuclei/configuration/nuclei_configs.py
+++ b/nuclei/nuclei/configuration/nuclei_configs.py
@@ -3,11 +3,13 @@
 from typing import Literal
 
 from pydantic import Field, PositiveInt, field_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class ConfigLoaderNuclei(BaseSettings):
     """Nuclei configurations"""
+
+    model_config = SettingsConfigDict(extra="ignore")
 
     scan_strategy: Literal["auto", "host-spray", "template-spray"] = Field(
         default="host-spray",


### PR DESCRIPTION
### Proposed changes

* Replacing `ENV` with `ARG` when an element is not required at runtime
* Specifying `extra=ignore` for pydantic base settings used in injectors' configuration

### Testing Instructions

1. Build and run the container version

### Related issues

* Closes #280 

### Checklist

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...-->