### PR TITLE
docs: standardize injector READMEs (#284)

### DIFF
--- a/ai-redteam/README.md
+++ b/ai-redteam/README.md
@@ -1,62 +1,260 @@
 # OpenAEV AI Red Team Injector
 
-Runs adversarial exposure validation against **LLM models and AI agents** and reports the outcome
-(plus findings and a correlation marker) back to OpenAEV. Techniques are mapped to **MITRE ATLAS**
-(`AML.Txxxx`) and **OWASP** (LLM 2025 / Agentic 2026), so AI injects flow through Atomic Testing,
-Scenarios and the ATLAS coverage matrix exactly like endpoint techniques.
+The AI Red Team injector lets OpenAEV run adversarial exposure validation against AI targets (LLM endpoints and AI
+agents) as part of attack scenarios. It launches prompt-injection, jailbreak, data-exfiltration, tool-abuse and MCP
+attacks through several engines (a built-in native engine plus optional NVIDIA Garak, Microsoft PyRIT and Promptfoo
+engines), evaluates whether the attack succeeded, and reports the result back to OpenAEV. Each technique maps to MITRE
+ATLAS and OWASP (LLM 2025 / Agentic 2026) references, and every inject raises detection and prevention expectations that
+an AI firewall / guardrail collector (for example prisma-airs) can later validate.
 
-## Engines
+## Table of Contents
 
-- **native** - single-turn adversarial prompts via a built-in multi-provider client, with heuristic
-  success detection (canary leakage / refusal / keywords). No heavy dependency.
-- **garak** - NVIDIA [Garak](https://github.com/NVIDIA/garak) broad probe scanner (120+ probes).
-- **pyrit** - Microsoft [PyRIT](https://github.com/Azure/PyRIT) multi-turn orchestration
-  (Crescendo / TAP / PAIR). Degrades to a built-in escalation loop if PyRIT is not installed.
-- **promptfoo** - [Promptfoo](https://promptfoo.dev) red-team plugins/strategies with
-  assertion-based pass/fail.
+- [OpenAEV AI Red Team Injector](#openaev-ai-red-team-injector)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [How it works](#how-it-works)
+  - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenAEV environment variables](#openaev-environment-variables)
+    - [Base injector environment variables](#base-injector-environment-variables)
+    - [AI Red Team injector environment variables](#ai-red-team-injector-environment-variables)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+  - [Inject contracts](#inject-contracts)
+  - [Target selection](#target-selection)
+  - [Behavior](#behavior)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
 
-The native and PyRIT (internal) engines work out of the box. To enable Garak and Promptfoo, build
-the image with `--build-arg INSTALL_OSS_ENGINES=true`.
+## Introduction
 
-## Native attack pack (mapped to ATLAS / OWASP)
+OpenAEV (Breach and Attack Simulation) drives injectors to execute the technical actions of a scenario. The AI Red Team
+injector registers a catalog of adversarial techniques with the OpenAEV platform; when an inject using one of these
+contracts is played, OpenAEV dispatches a job to the injector, which runs the corresponding attack against the AI target
+and returns a verdict (vulnerable / defended) together with structured outputs. Each outbound request carries a
+per-inject canary marker so an in-line AI defense (LLM firewall / guardrail / AI gateway) can log it and a defense
+collector can correlate its detection / prevention event back to the inject.
 
-- Direct prompt injection - `AML.T0051.000` / LLM01
-- Indirect prompt injection - `AML.T0051.001` / LLM01
-- Jailbreak - `AML.T0054` / LLM01
-- System prompt leakage - `AML.T0056` / LLM07
-- Sensitive data exfiltration - `AML.T0057` / LLM02
-- Excessive agency / tool abuse - `AML.T0053` / LLM06 / ASI02
-- MCP tool poisoning - `AML.T0108` / ASI04 / ASI06
-- Unbounded consumption / cost harvesting - `AML.T0034` / LLM10
+## How it works
 
-## Targets
+Injectors receive their jobs through the message broker (RabbitMQ) configured by the OpenAEV platform. The injector
+fetches the broker connection details from OpenAEV at startup, so it only needs to be able to reach the OpenAEV URL and
+the RabbitMQ host/port advertised by the platform. To run an attack, the injector also needs outbound network access to
+the AI target endpoint being tested.
 
-An inject selects a target either by referencing an **AI Target** asset id (contract field
-`ai_target`) - fetched from the platform - or by providing the connection inline
-(`target_provider`, `target_endpoint`, `target_model`, `target_api_key_variable`, `system_prompt`).
+## Requirements
 
-Supported providers: OpenAI-compatible, Anthropic, Azure OpenAI, AWS Bedrock, Google Vertex,
-HuggingFace, Ollama, custom HTTP, MCP server, agent HTTP.
+- A running OpenAEV platform, reachable from the injector (along with its RabbitMQ broker)
+- Outbound network access to the AI target endpoints you want to test
+- Engines:
+  - The `native` engine and the `PyRIT multi-turn campaign` (built-in escalation loop) work out of the box, with no
+    extra tooling.
+  - The `Garak` and `Promptfoo` contracts require their tools to be available (the `garak` Python package and the
+    `promptfoo` Node CLI). When absent, those contracts return a clear error instead of failing silently. In Docker,
+    bake them in with the `INSTALL_OSS_ENGINES=true` build argument.
+- For a manual (non-Docker) deployment:
+  - Python >= 3.11 and [Poetry](https://python-poetry.org/) >= 2.1
+  - Optionally `garak` (`pip install garak`) and `promptfoo` (`npm install -g promptfoo`) on the `PATH` to enable those
+    engines
 
-## Security: credentials
+> Unlike the other injectors in this repository, the AI Red Team image does not depend on the shared `injector_common`
+> package, so its Docker build does not require the `--build-context injector_common=../injector_common` option.
 
-Secrets are **never** stored by the platform. Each AI Target carries only the *name* of the
-environment variable (`api_key_variable`); the injector resolves the actual secret from its own
-process environment at execution time (e.g. `OPENAI_API_KEY`).
+## Configuration variables
 
-## Correlation with AI defenses
+The injector is configured either through environment variables (recommended, read from `docker-compose.yml` / the
+`.env` file for a Docker deployment) or through a `config.yml` file (for a manual deployment). Copy the provided
+`.env.sample` / `config.yml.sample` and fill in the values flagged with `ChangeMe`.
 
-Every request carries a per-inject canary marker (`X-OAEV-Inject-Marker` header + in-prompt token).
-An in-line LLM firewall / guardrail logs the marker, and the AI defense collectors then fill the
-DETECTION / PREVENTION expectations by matching it - closing the attack + defense loop.
+### OpenAEV environment variables
 
-## Run (dev)
+| Parameter         | config.yml          | Docker environment variable | Mandatory | Description                                                                        |
+|-------------------|---------------------|-----------------------------|-----------|------------------------------------------------------------------------------------|
+| OpenAEV URL       | `openaev.url`       | `OPENAEV_URL`               | Yes       | The URL of the OpenAEV platform. Must be reachable from where the injector runs.   |
+| OpenAEV Token     | `openaev.token`     | `OPENAEV_TOKEN`             | Yes       | The administrator token of the OpenAEV platform.                                   |
+| OpenAEV Tenant ID | `openaev.tenant_id` | `OPENAEV_TENANT_ID`         | No        | Tenant identifier for multi-tenant deployments. When set, it must be a valid UUID. |
 
-```bash
-poetry install --extras dev
-export OPENAI_API_KEY=sk-...
+### Base injector environment variables
+
+| Parameter     | config.yml           | Docker environment variable | Default      | Mandatory | Description                                                     |
+|---------------|----------------------|-----------------------------|--------------|-----------|-----------------------------------------------------------------|
+| Injector ID   | `injector.id`        | `INJECTOR_ID`               | /            | Yes       | A unique `UUIDv4` identifier for this injector instance.        |
+| Injector Name | `injector.name`      | `INJECTOR_NAME`             | AI Red Team  | No        | The name of the injector as shown in OpenAEV.                   |
+| Log Level     | `injector.log_level` | `INJECTOR_LOG_LEVEL`        | warn         | No        | Verbosity of the logs. One of `debug`, `info`, `warn`, `error`. |
+
+### AI Red Team injector environment variables
+
+| Parameter       | config.yml                         | Docker environment variable         | Default | Mandatory | Description                                              |
+|-----------------|------------------------------------|-------------------------------------|---------|-----------|----------------------------------------------------------|
+| Request timeout | `injector.request_timeout_seconds` | `INJECTOR_REQUEST_TIMEOUT_SECONDS`  | 120     | No        | HTTP timeout (in seconds) for a single request to an AI target. |
+
+Provider credentials are not stored in OpenAEV and are not part of `config.yml`. The injector resolves each secret from
+its own process environment, using the variable name carried by the AI target (`api_key_variable`). Set the relevant
+variables on the injector (in `.env` / `docker-compose.yml`) and reference them by name on each target. Common examples:
+
+| Docker environment variable | Used by                                                          |
+|-----------------------------|------------------------------------------------------------------|
+| `OPENAI_API_KEY`            | OpenAI-compatible / Azure OpenAI / Bedrock / Vertex targets      |
+| `ANTHROPIC_API_KEY`         | Anthropic targets                                                |
+| `AZURE_OPENAI_API_KEY`      | Azure OpenAI targets                                             |
+| `HF_INFERENCE_TOKEN`        | Hugging Face inference targets                                   |
+
+Add as many credential variables as you need for the providers you test; any variable name can be used as long as the
+target's `API key variable` field references it.
+
+## Deployment
+
+### Docker Deployment
+
+This injector does not depend on the shared `injector_common` package, so a plain build context is enough:
+
+```shell
+docker build . -t openaev/injector-ai-redteam:latest
+```
+
+To bake the heavy OSS engines (Garak, PyRIT, Promptfoo) into the image, pass the build argument:
+
+```shell
+docker build --build-arg INSTALL_OSS_ENGINES=true . -t openaev/injector-ai-redteam:latest
+```
+
+Create a `.env` file from `.env.sample` and fill in your values, then start the injector with the provided
+`docker-compose.yml`:
+
+```shell
+docker compose up -d
+```
+
+> If OpenAEV runs on your host machine while the injector runs in a container, set `OPENAEV_URL` to
+> `http://host.docker.internal:<port>` rather than `localhost`. On Linux, also add
+> `extra_hosts: ["host.docker.internal:host-gateway"]` to the service, and make sure OpenAEV listens on `0.0.0.0`.
+
+### Manual Deployment
+
+Create a `config.yml` from `config.yml.sample`, then install and run the injector:
+
+```shell
+poetry install --extras prod
 poetry run python -m ai_redteam.openaev_ai_redteam
 ```
 
-> As with the other connectors in this repository, the icon
-> (`ai_redteam/img/icon-ai-redteam.png`) is provided at build/deploy time.
+> For local development against a checkout of [client-python](https://github.com/OpenAEV-Platform/client-python)
+> (cloned at `../../client-python`), use `poetry install --extras dev`. To enable the Garak and Promptfoo engines,
+> also install `garak` (`pip install garak`) and `promptfoo` (`npm install -g promptfoo`).
+
+## Usage
+
+Once started, the injector registers its contracts with OpenAEV and waits for jobs. Add an AI Red Team inject to a
+scenario or atomic testing, choose the technique, point it at an AI target (an `AI Target` asset or inline connection
+details), adjust the attack prompt / engine options, and play it: the verdict and the model response are attached to the
+inject once the run completes.
+
+## Inject contracts
+
+All contracts are exposed under the `AI Red Team` label and are tagged with their MITRE ATLAS attack pattern(s). The
+native techniques send a single adversarial prompt and score the response heuristically:
+
+| Contract                                            | Engine | MITRE ATLAS    | OWASP                                          |
+|-----------------------------------------------------|--------|----------------|------------------------------------------------|
+| AI Red Team - Direct prompt injection               | native | AML.T0051.000  | LLM01:2025 Prompt Injection                    |
+| AI Red Team - Indirect prompt injection             | native | AML.T0051.001  | LLM01:2025 Prompt Injection                    |
+| AI Red Team - Jailbreak                             | native | AML.T0054      | LLM01:2025 Prompt Injection                    |
+| AI Red Team - System prompt leakage                 | native | AML.T0056      | LLM07:2025 System Prompt Leakage               |
+| AI Red Team - Sensitive data exfiltration           | native | AML.T0057      | LLM02:2025 Sensitive Information Disclosure    |
+| AI Red Team - Excessive agency / tool abuse         | native | AML.T0053      | LLM06:2025 Excessive Agency / Agentic ASI02    |
+| AI Red Team - MCP tool poisoning                    | native | AML.T0108      | Agentic ASI04 / ASI06                          |
+| AI Red Team - MCP tool shadowing                    | native | AML.T0108      | Agentic ASI04 / ASI02                          |
+| AI Red Team - Unbounded consumption / cost harvesting | native | AML.T0034    | LLM10:2025 Unbounded Consumption               |
+
+The engine-backed contracts run a broader campaign through a dedicated framework:
+
+| Contract                                  | Engine    | Description                                                                                  |
+|-------------------------------------------|-----------|----------------------------------------------------------------------------------------------|
+| AI Red Team - Garak vulnerability scan    | garak     | Broad-spectrum probe scan with NVIDIA Garak (requires `garak`).                              |
+| AI Red Team - PyRIT multi-turn campaign   | pyrit     | Adaptive multi-turn orchestration (Crescendo / TAP / PAIR). Works out of the box via a built-in escalation loop; Microsoft PyRIT can be installed for a richer integration. |
+| AI Red Team - Promptfoo red-team / regression | promptfoo | Declarative plugin/strategy red-teaming with assertion-based pass/fail (requires `promptfoo`). |
+
+Every contract shares the AI target fields (see [Target selection](#target-selection)) and the following:
+
+- Technique-specific inputs:
+  - Native: `Attack prompt` (mandatory; `{marker}` is replaced with the inject canary), `Obfuscation converter`
+    (`none`, `base64`, `rot13`, `leetspeak`, `unicode_escape`, `reverse`), and `Extra success keywords` (comma-separated).
+  - Garak: `Garak probes` (comma-separated, default `promptinject`) and `Generations per probe` (default `3`).
+  - PyRIT: `Attack objective` (mandatory), `Orchestration strategy` (`crescendo`, `tap`, `pair`, `red_teaming`) and
+    `Max turns` (default `5`).
+  - Promptfoo: `Plugins` (comma-separated, default `prompt-injection`) and `Strategies` (comma-separated, default
+    `jailbreak`).
+- Expectations (predefined, score 100 each): `Not vulnerable` (vulnerability), `Detected` (detection), `Prevented`
+  (prevention). The detection and prevention expectations are what an AI firewall / guardrail collector validates.
+- Outputs: `response` (the model output, text) and `vulnerability` (finding-compatible, populated when the attack
+  succeeds).
+
+## Target selection
+
+The target of an AI Red Team inject is an AI endpoint, not an OpenAEV asset or IP. It can be provided in two ways:
+
+- Reference an `AI Target` asset by id (field `AI Target id`). The injector fetches the target definition from the
+  platform (`/ai_targets/{id}`).
+- Provide the connection inline on the inject: `Provider`, `Endpoint URL`, `Model`, `API key variable` and an optional
+  `System prompt`. Inline values can also override the system prompt of a referenced target.
+
+The supported providers are:
+
+| Provider            | Notes                                                          |
+|---------------------|----------------------------------------------------------------|
+| `OPENAI_COMPATIBLE` | OpenAI-style `/chat/completions` API (default)                 |
+| `AZURE_OPENAI`      | OpenAI-compatible API with an `api-key` header                 |
+| `AWS_BEDROCK`       | Handled through the OpenAI-compatible path                     |
+| `GOOGLE_VERTEX`     | Handled through the OpenAI-compatible path                     |
+| `ANTHROPIC`         | Anthropic `/v1/messages` API                                   |
+| `HUGGINGFACE`       | Hugging Face inference endpoint (endpoint URL required)        |
+| `OLLAMA`            | Local Ollama `/api/chat` API                                   |
+| `CUSTOM_HTTP`       | Generic HTTP POST (request/response shape is configurable)     |
+| `AGENT_HTTP`        | Generic HTTP POST for an AI agent endpoint                     |
+| `MCP_SERVER`        | Generic HTTP POST for an MCP server endpoint                   |
+
+Credentials are never read from OpenAEV. The secret is resolved from the injector process environment using the
+variable name carried by the target (`API key variable`), for example `OPENAI_API_KEY`. If the variable is unset, the
+request is sent without an authorization header.
+
+## Behavior
+
+```mermaid
+flowchart LR
+    O[OpenAEV inject] -->|job via RabbitMQ| I(AI Red Team injector)
+    I -->|resolve target| T[AI Target asset / inline]
+    I -->|engine: native / garak / pyrit / promptfoo| E[Attack engine]
+    E -->|prompt + X-OAEV-Inject-Marker header| M[AI target LLM / agent]
+    M -->|response| E
+    E -->|verdict + outputs| I
+    I -->|vulnerability / detection / prevention| O
+    M -.observed by.-> F[AI firewall / guardrail]
+```
+
+On each job the injector acknowledges reception, resolves the AI target, builds the per-inject canary marker, selects
+the engine bound to the contract, and runs the attack. The native engine sends a single converted prompt and scores the
+response with a heuristic detector (canary leakage, success keywords, refusal detection); the engine-backed contracts
+delegate to Garak, PyRIT or Promptfoo. The injector then returns the verdict, the (truncated) model response and any
+vulnerability findings, with a success or error status. The canary marker is sent as the `X-OAEV-Inject-Marker` request
+header so an in-line AI defense and its collector can correlate detection / prevention back to the inject.
+
+## Debugging
+
+Set `INJECTOR_LOG_LEVEL=debug` to log the resolved provider, model and endpoint for each inject. Common issues:
+
+- `No engine registered for contract ...`: an unknown contract id was received.
+- `Garak is not installed ...` / `Promptfoo is not installed ...`: build the image with `INSTALL_OSS_ENGINES=true`, or
+  install the tool on the `PATH` for a manual deployment.
+- `Error calling AI target ...` or timeouts: check the endpoint URL, the resolved API key variable and
+  `INJECTOR_REQUEST_TIMEOUT_SECONDS`.
+
+## Additional information
+
+- Curated, ready-to-assemble scenarios: [docs/CURATED_SCENARIOS.md](docs/CURATED_SCENARIOS.md)
+- MITRE ATLAS: [https://atlas.mitre.org/](https://atlas.mitre.org/)
+- OWASP Top 10 for LLM Applications: [https://genai.owasp.org/](https://genai.owasp.org/)
+- NVIDIA Garak: [https://github.com/NVIDIA/garak](https://github.com/NVIDIA/garak)
+- Microsoft PyRIT: [https://github.com/Azure/PyRIT](https://github.com/Azure/PyRIT)
+- Promptfoo: [https://promptfoo.dev](https://promptfoo.dev)

--- a/aws/README.md
+++ b/aws/README.md
@@ -1,352 +1,203 @@
 # OpenAEV AWS Injector
 
-## Overview
+The AWS injector lets OpenAEV run cloud security assessments against an AWS account as part of attack scenarios, using
+[Pacu](https://github.com/RhinoSecurityLabs/pacu) (the AWS exploitation framework by Rhino Security Labs) together with
+the [AWS CLI](https://aws.amazon.com/cli/). It exposes a set of inject contracts that, for a given set of AWS credentials
+supplied in the inject, run read-only enumeration modules (IAM, EC2, S3, Lambda, CloudTrail, VPC, RDS and more) plus one
+active "IAM Create User" attack action, then report the discovered resources back to OpenAEV as structured findings.
 
-The OpenAEV injector allows security teams to perform comprehensive AWS security assessments directly from OpenAEV.
+## Table of Contents
 
-## Features
+- [OpenAEV AWS Injector](#openaev-aws-injector)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [How it works](#how-it-works)
+  - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenAEV environment variables](#openaev-environment-variables)
+    - [Base injector environment variables](#base-injector-environment-variables)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+  - [Inject contracts](#inject-contracts)
+  - [Target selection](#target-selection)
+  - [Behavior](#behavior)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
 
-### Supported AWS Modules
+## Introduction
 
-The injector provides contracts for the following AWS capabilities:
+OpenAEV (Breach and Attack Simulation) drives injectors to execute the technical actions of a scenario. The AWS injector
+registers a set of AWS assessment contracts with the OpenAEV platform; when an inject using one of these contracts is
+played, OpenAEV dispatches a job to the injector, which runs the corresponding Pacu module or AWS CLI command against the
+AWS account behind the credentials provided in the inject, and returns the results.
 
-#### Attack Actions
-Some contracts perform active attacks rather than passive enumeration:
-- **IAM Create User**: Creates a new IAM user for persistence (marked as Attack)
-- These actions modify the target AWS environment and should be used with caution
+## How it works
 
-#### Enumeration & Discovery
-Most contracts perform read-only enumeration:
+Injectors receive their jobs through the message broker (RabbitMQ) configured by the OpenAEV platform. The injector
+fetches the broker connection details from OpenAEV at startup, so it only needs to be able to reach the OpenAEV URL and
+the RabbitMQ host/port advertised by the platform.
 
-#### IAM (Identity and Access Management)
-- **IAM Enumerate Permissions**: Discover IAM permissions for the current user/role
-- **IAM Enumerate Users, Roles, Policies & Groups**: Comprehensive IAM enumeration
-- **IAM Enumerate Roles**: List all IAM roles in the AWS account
-- **IAM Privilege Escalation Scan**: Identify potential privilege escalation paths
-- **IAM Get Account Password Policy**: Retrieve and analyze the AWS account password policy settings
-- **IAM Create User (Attack)**: Create a new IAM user in the target AWS account (requires username parameter)
+## Requirements
 
-#### EC2 (Elastic Compute Cloud)
-- **EC2 Enumerate**: Comprehensive EC2 enumeration including instances and security groups
-
-#### S3 (Simple Storage Service)
-- **S3 List Buckets**: List S3 buckets using AWS CLI integration
-- **S3 Download Bucket**: Download contents from specific S3 buckets
-
-#### Lambda
-- **Lambda Enumerate**: List all Lambda functions and their configurations
-
-#### CloudTrail
-- **CloudTrail Download Event History**: Download and analyze CloudTrail events
-
-#### VPC (Virtual Private Cloud)
-- **VPC Enumerate Lateral Movement**: Map VPC configurations for lateral movement analysis
-
-#### RDS (Relational Database Service)
-- **RDS Enumerate**: List all RDS database instances
-
-#### Secrets Manager
-- **Secrets Enumerate**: Discover stored secrets and their metadata
-
-#### Systems Manager (SSM)
-- **SSM Download Parameters**: Download SSM Parameter Store entries
-
-#### Organizations
-- **Organizations Enumerate**: Map AWS Organizations structure
-
-#### Additional Services
-- **EBS Enumerate Snapshots**: Enumerate EBS snapshots (unauthenticated)
-- **DynamoDB Enumerate**: List DynamoDB tables
-- **ECR Enumerate**: List ECR repositories
-- **ECS Enumerate**: Enumerate ECS clusters
-- **EKS Enumerate**: Enumerate EKS clusters
-- **GuardDuty List Findings**: List GuardDuty security findings
-- **Cognito Enumerate**: Enumerate Cognito user pools
-- **Glue Enumerate**: List Glue databases
-- **Route53 Enumerate**: List Route53 hosted zones
-- **SNS Enumerate**: List SNS topics
-
-### AWS CLI Integration
-
-The injector supports direct AWS CLI command execution through AWS, enabling:
-- Custom S3 operations (`s3 ls`, `s3 cp`, etc.)
-- Any AWS CLI command for services not directly supported by AWS modules
-- Flexible command customization through the contract interface
-
-### Supported AWS Regions
-
-The injector supports all current AWS regions including:
-
-**North America**: US East (N. Virginia, Ohio), US West (N. California, Oregon), Canada (Central, Calgary)
-
-**Europe**: Ireland, London, Paris, Frankfurt, Zurich, Stockholm, Milan, Spain
-
-**Asia Pacific**: Tokyo, Seoul, Singapore, Sydney, Mumbai, Hong Kong, Jakarta, Melbourne, Hyderabad, Kuala Lumpur, Bangkok, Osaka
-
-**Other Regions**: Middle East (Bahrain, UAE, Tel Aviv), Africa (Cape Town), South America (São Paulo), China (Beijing, Ningxia), AWS GovCloud (US-East, US-West)
+- A running OpenAEV platform, reachable from the injector (along with its RabbitMQ broker).
+- The injector executes the `pacu` and `aws` (AWS CLI) commands. Both are installed as Python dependencies (`pacu` and
+  `awscli`, pinned in `pyproject.toml`), so they are bundled in the Docker image and pulled in automatically by
+  `poetry install` for a manual deployment - no separate system package is required.
+- The Docker image must be built with `--build-context injector_common=../injector_common`, because the injector depends
+  on the shared `injector_common` package located one level above this directory.
+- For a manual (non-Docker) deployment:
+  - Python >= 3.11 and [Poetry](https://python-poetry.org/) >= 2.1.
 
 ## Configuration variables
 
-There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or
-in `config.yml` (for manual deployment).
+The injector is configured either through environment variables (recommended, read from `docker-compose.yml` / the
+`.env` file for a Docker deployment) or through a `config.yml` file (for a manual deployment). Copy the provided
+`.env.sample` / `config.yml.sample` and fill in the values flagged with `ChangeMe`.
+
+AWS credentials are not part of the injector configuration: they are supplied per inject (see [Usage](#usage) and
+[Target selection](#target-selection)).
 
 ### OpenAEV environment variables
 
-Below are the parameters you'll need to set for OpenAEV:
-
-| Parameter         | config.yml | Docker environment variable | Mandatory | Description                                           |
-|-------------------|------------|-----------------------------|-----------|-------------------------------------------------------|
-| OpenAEV URL       | url        | `OPENAEV_URL`               | Yes       | The URL of the OpenAEV platform.                      |
-| OpenAEV Token     | token      | `OPENAEV_TOKEN`             | Yes       | The default admin token set in the OpenAEV platform.  |
-| OpenAEV Tenant ID | tenant_id  | `OPENAEV_TENANT_ID`         | No        | Identifier of the tenant within the OpenAEV platform. |
-
-> ⚠️ Warning ⚠️
->
-> The `tenant_id` parameter is a new configuration option. A period of backward compatibility is ensured: if this key is not defined,
-> existing configurations will not be affected, and the default value will be `None`. However, if a value is provided, it will be
-> validated by Pydantic and must conform to a valid UUID format, otherwise, a validation error will be returned.
+| Parameter         | config.yml          | Docker environment variable | Mandatory | Description                                                                        |
+|-------------------|---------------------|-----------------------------|-----------|------------------------------------------------------------------------------------|
+| OpenAEV URL       | `openaev.url`       | `OPENAEV_URL`               | Yes       | The URL of the OpenAEV platform. Must be reachable from where the injector runs.   |
+| OpenAEV Token     | `openaev.token`     | `OPENAEV_TOKEN`             | Yes       | The administrator token of the OpenAEV platform.                                   |
+| OpenAEV Tenant ID | `openaev.tenant_id` | `OPENAEV_TENANT_ID`         | No        | Tenant identifier for multi-tenant deployments. When set, it must be a valid UUID. |
 
 ### Base injector environment variables
 
-Below are the parameters you'll need to set for running the injector properly:
-
-| Parameter        | config.yml | Docker environment variable | Default | Mandatory | Description                                                                            |
-|------------------|------------|-----------------------------|---------|-----------|----------------------------------------------------------------------------------------|
-| Injector ID      | id         | `INJECTOR_ID`               | /       | Yes       | A unique `UUIDv4` identifier for this injector instance.                               |
-| Collector Name   | name       | `INJECTOR_NAME`             | AWS     | Yes       | Name of the injector.                                                                  |
-| Log Level        | log_level  | `INJECTOR_LOG_LEVEL`        | error   | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`. |
-
+| Parameter     | config.yml           | Docker environment variable | Default | Mandatory | Description                                                     |
+|---------------|----------------------|-----------------------------|---------|-----------|-----------------------------------------------------------------|
+| Injector ID   | `injector.id`        | `INJECTOR_ID`               | /       | Yes       | A unique `UUIDv4` identifier for this injector instance.        |
+| Injector Name | `injector.name`      | `INJECTOR_NAME`             | AWS     | No        | The name of the injector as shown in OpenAEV.                   |
+| Log Level     | `injector.log_level` | `INJECTOR_LOG_LEVEL`        | error   | No        | Verbosity of the logs. One of `debug`, `info`, `warn`, `error`. |
 
 ## Deployment
 
-### Using Docker
+### Docker Deployment
 
-1. Build the Docker image:
-```bash
-cd aws
-docker build --build-context injector_common=../injector_common -t openaev/injector-aws:latest .
-```
-
-2. Run with docker-compose:
-```bash
-docker-compose up -d
-```
-
----
-
-#### Domain name resolution - Local openAEV with Injector container
-**Note:** If you are running OpenAEV locally on your host machine and want to run this injector inside a Docker container, the `openaev` URL defined in `config.yml` and `.env` must be reachable from inside the container.
-
-Inside a container, `localhost` refers to the container itself - not your host machine. Therefore, you cannot use `localhost` as the OpenAEV URL unless OpenAEV is running inside the same container.
-
-Instead, use: `host.docker.internal`. This hostname allows the container to access services running on your host machine.
-
-**In short**:
-- `localhost` -> container itself
-- `host.docker.internal` -> your host machine
-
-**Platform-specific notes**:
-- **macOS / Windows (Docker Desktop):**     
-  `host.docker.internal` works out of the box. No additional configuration is needed.
-- **Linux:**  
-  You must explicitly map it using `extra_hosts`:
-```yaml
-services:
-  your-injector-name:
-    image: your-image-name
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-```
-
-**Important**:
-- Avoid mapping `host.docker.internal` to a fixed IP (e.g. `1.2.3.4`) unless you have a specific reason. The host IP can change, and Docker provides `host-gateway` to handle this dynamically.
-- Make sure your OpenAEV service is listening on `0.0.0.0` (not just `localhost`), otherwise it may NOT be accessible from the container.
-
----
-
-### Manual Installation
-
-Create a file `config.yml` based on the provided `config.yml.sample`.
-
-Replace the configuration variables with the appropriate configurations for
-you environment.
-
-The poetry package management system (version 2.1 or later) must also be available: https://python-poetry.org/
-
-Install the environment:
-
-**Production**:
-```shell
-# production environment
-poetry install 
-```
-
-**Development** (note that you should also clone the [pyoaev](OpenAEV-Platform/client-python) repository [according to
-these instructions](../README.md#simultaneous-development-on-pyoaev-and-an-injector))
-```shell
-# development environment
-poetry install --extras dev
-```
-
-Then, start the collector:
+This injector depends on the shared `injector_common` package, so the image must be built with a build context that
+exposes it:
 
 ```shell
+docker build --build-context injector_common=../injector_common . -t openaev/injector-aws:latest
+```
+
+Create a `.env` file from `.env.sample` and fill in your values, then start the injector with the provided
+`docker-compose.yml`:
+
+```shell
+docker compose up -d
+```
+
+> If OpenAEV runs on your host machine while the injector runs in a container, set `OPENAEV_URL` to
+> `http://host.docker.internal:<port>` rather than `localhost`. On Linux, also add
+> `extra_hosts: ["host.docker.internal:host-gateway"]` to the service, and make sure OpenAEV listens on `0.0.0.0`.
+
+### Manual Deployment
+
+Create a `config.yml` from `config.yml.sample`, then install and run the injector (the `aws` and `pacu` commands are
+provided by the installed Python dependencies):
+
+```shell
+poetry install
 poetry run python -m aws.openaev_aws
 ```
 
-## Behaviour
+> For local development against a checkout of [client-python](https://github.com/OpenAEV-Platform/client-python)
+> (cloned next to this repository), use `poetry install --extras dev`.
 
-1. **Deploy the Injector**: Start the AWS injector using Docker or manual installation
-2. **Verify Registration**: Check that the injector appears in OpenAEV under Integrations > Injectors
-3. **Create Injects**: Use the AWS contracts to create AWS security assessment injects
-4. **Provide AWS Credentials**: Each inject requires:
-   - AWS Access Key ID
-   - AWS Secret Access Key
-   - AWS Session Token (optional, for temporary credentials)
-   - AWS Region (40+ regions supported)
-5. **Execute and Monitor**: Run the injects and monitor results in OpenAEV
+## Usage
 
-## Technical Details
+Once started, the injector registers its contracts with OpenAEV and waits for jobs. Add an AWS inject to a scenario or
+atomic testing, choose the contract (the AWS module to run) and fill in the credentials of the account to assess, then
+play it: the results are attached to the inject once the module completes.
 
-### Session Management
+Each inject carries the AWS credentials and parameters used for the run:
 
-The injector automatically manages AWS sessions:
-- Creates a session named `openaev_session` if it doesn't exist
-- Handles Windows-specific readline issues with non-interactive execution
-- Properly manages AWS credentials through environment variables
+| Field                  | Content key             | Mandatory                       | Description                                                                |
+|------------------------|-------------------------|---------------------------------|----------------------------------------------------------------------------|
+| AWS Access Key ID      | `aws_access_key_id`     | Yes                             | Access key of the AWS account/identity to assess.                          |
+| AWS Secret Access Key  | `aws_secret_access_key` | Yes                             | Secret access key paired with the access key.                              |
+| AWS Session Token      | `aws_session_token`     | No                              | Session token, for temporary (STS) credentials.                            |
+| AWS Region             | `aws_region`            | Yes                             | Target region (default `us-east-1`). All standard, China and GovCloud regions are available. |
+| Username to create     | `username`              | Yes (IAM Create User only)      | Name of the IAM user to create.                                            |
+| S3 Bucket Name         | `bucket_name`           | Yes (S3 Download Bucket only)   | Name of the bucket whose contents are downloaded.                          |
 
-### Error Handling
+## Inject contracts
 
-- Comprehensive error reporting with actual server error messages
-- Proper handling of AWS execution failures and timeouts
-- Signal handling for interrupted executions (SIGINT, SIGTERM)
-- Fallback mechanisms for module execution
+All contracts share the label "AWS Exploitation" and the `CLOUD` security domain. Every contract is read-only
+enumeration except "IAM Create User (Attack)", which actively creates an IAM user, and "S3 Download Bucket", which
+downloads bucket contents. Most contracts run a Pacu module; a few rely on the AWS CLI.
 
-### Module Execution
+| AWS service    | Contract(s)                                                                                                              | Engine                                            |
+|----------------|--------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
+| IAM            | IAM Enumerate Permissions; IAM Enumerate Users, Roles, Policies and Groups; IAM Enumerate Roles; IAM Privilege Escalation Scan | Pacu (`iam__*`)                              |
+| IAM (AWS CLI)  | IAM Get Account Password Policy; IAM Create User (Attack)                                                                 | AWS CLI (`aws iam get-account-password-policy` / `aws iam create-user`) |
+| EC2            | EC2 Enumerate Instances; EC2 Enumerate Security Groups                                                                    | Pacu (`ec2__enum`)                                |
+| S3             | S3 List Buckets                                                                                                          | AWS CLI (`aws s3 ls`)                             |
+| S3             | S3 Download Bucket                                                                                                       | Pacu (`s3__download_bucket`)                      |
+| Lambda         | Lambda Enumerate Functions                                                                                              | Pacu (`lambda__enum`)                             |
+| CloudTrail     | CloudTrail Enumerate Trails                                                                                             | Pacu (`cloudtrail__download_event_history`)       |
+| VPC            | VPC Enumerate Networks                                                                                                  | Pacu (`vpc__enum_lateral_movement`)               |
+| RDS            | RDS Enumerate Databases                                                                                                 | Pacu (`rds__enum`)                                |
+| Secrets Manager| Secrets Manager Enumerate                                                                                               | Pacu (`secrets__enum`)                            |
+| SSM            | SSM Enumerate Parameters                                                                                                | Pacu (`systemsmanager__download_parameters`)      |
+| Organizations  | Organizations Enumerate                                                                                                 | Pacu (`organizations__enum`)                      |
+| EBS            | EBS Enumerate Snapshots                                                                                                 | Pacu (`ebs__enum_public_snapshots_unauthenticated`) |
+| DynamoDB       | DynamoDB Enumerate Tables                                                                                               | Pacu (`dynamodb__enum`)                           |
+| ECR            | ECR Enumerate Repositories                                                                                              | Pacu (`ecr__enum`)                                |
+| ECS            | ECS Enumerate Clusters                                                                                                  | Pacu (`ecs__enum`)                                |
+| EKS            | EKS Enumerate Clusters                                                                                                  | Pacu (`eks__enum`)                                |
+| GuardDuty      | GuardDuty List Findings                                                                                                 | Pacu (`guardduty__list_findings`)                 |
+| Cognito        | Cognito Enumerate User Pools                                                                                            | Pacu (`cognito__enum`)                            |
+| Glue           | Glue Enumerate Databases                                                                                                | Pacu (`glue__enum`)                               |
+| Route53        | Route53 Enumerate Zones                                                                                                 | Pacu (`route53__enum`)                            |
+| SNS            | SNS Enumerate Topics                                                                                                    | Pacu (`sns__enum`)                                |
 
-- Direct AWS CLI integration for reliable execution
-- AWS credentials passed via environment variables for security
-- Non-interactive execution to prevent hanging on prompts
-- Proper timeout handling (10 minutes default)
+Pacu modules are run through the Pacu CLI in a non-interactive session named `openaev_session`; their textual output is
+parsed into the structured findings (users, roles, buckets, instances, etc.) attached to the inject.
 
-## Security Considerations
+## Target selection
 
-### AWS Credentials
+This injector does not target OpenAEV assets. The "target" of every inject is the AWS account reached through the
+credentials carried by the inject itself: the AWS Access Key ID, AWS Secret Access Key, optional AWS Session Token and
+AWS Region. The injector exports these as environment variables for the duration of the run and lets Pacu and the AWS CLI
+operate against that account.
 
-- **Never hardcode AWS credentials** in configuration files
-- Credentials are passed via environment variables, not stored
-- Use temporary credentials with limited scope when possible
-- Consider using AWS IAM roles for EC2 instances running the injector
-- Rotate credentials regularly
+As a result, there is no asset / asset-group / manual selector and no target-property mapping. The blast radius of each
+inject is whatever the supplied credentials are entitled to do in the selected region.
 
-### Permissions
+## Behavior
 
-The AWS credentials used with this injector should have appropriate read-only permissions for assessment purposes. Avoid using credentials with write/delete permissions unless specifically required for the assessment.
-
-### Network Security
-
-- Run the injector in a secure, isolated network segment
-- Use TLS/SSL for communication with OpenAEV
-- Implement proper firewall rules
-- No debug logging in production to avoid credential exposure
-
-## Development
-
-### Adding New AWS Modules
-
-To add support for additional AWS modules:
-
-1. Add new contract IDs in `contracts_aws.py`
-2. Define the contract with appropriate fields and outputs using the `make_contract` helper
-3. Implement the execution method in `helpers/aws_executor.py`
-4. Map the contract to the execution method in `openaev_aws.py`
-5. Update the module name mapping in `_get_module_name()`
-
-### Testing
-
-Run the injector with info logging to test new modules:
-
-```yaml
-# In config.yml
-injector:
-  log_level: 'info'
+```mermaid
+flowchart LR
+    O[OpenAEV inject] -->|job via RabbitMQ| I(AWS injector)
+    I -->|per-inject credentials| C[AWS account]
+    I -->|Pacu module or AWS CLI| P[Pacu / AWS CLI]
+    P -->|enumeration output| I
+    I -->|structured findings| O
 ```
 
-## Troubleshooting
+On each job the injector acknowledges reception, reads the AWS credentials and region from the inject, configures the
+AWS environment, resolves the contract to its Pacu module or AWS CLI command, runs it, parses the output into structured
+findings, and returns a success or error status to OpenAEV.
 
-### Common Issues
+## Debugging
 
-1. **Injector not appearing in OpenAEV**
-   - Verify network connectivity to OpenAEV
-   - Check authentication token is valid
-   - Review logs for connection errors
+Set `INJECTOR_LOG_LEVEL=debug` (or `info`) to log the selected region, the module being executed and the parsing steps.
+Common issues:
 
-2. **AWS Authentication Failures**
-   - Verify AWS credentials are correct
-   - Check if credentials have necessary permissions
-   - Ensure correct region is selected
-   - Note: Some modules require specific permissions
+- Authentication failures (`Unable to locate credentials`, `AccessDenied`): verify the key/secret/token, the region and
+  the permissions attached to the identity.
+- A module returns no data: the credentials may lack the permissions required by that specific service.
 
-3. **Module Execution Errors**
-   - Check AWS is properly installed (`aws --help`)
-   - Verify Python dependencies are up to date
-   - Review execution logs for specific error messages
-   - Ensure AWS session exists or can be created
+## Additional information
 
-4. **SIGINT/Readline Errors (Windows)**
-   - This is handled automatically by the injector
-   - Sessions are created using echo commands on Windows
-   - If issues persist, try running AWS manually first
-
-### Known Limitations
-
-- Some AWS modules may not exist or have different names than expected
-- S3 enumeration uses AWS CLI instead of a dedicated AWS module
-- Windows environments may have readline compatibility issues (handled automatically)
-
-### Logging
-
-Logs are output to stdout/stderr in JSON format. When running in Docker, view logs with:
-
-```bash
-docker-compose logs -f injector-aws
-```
-
-Log format includes:
-- Timestamp
-- Log level (INFO, WARNING, ERROR)
-- Logger name
-- Message
-- Exception info (when applicable)
-
-## Contributing
-
-Contributions are welcome! Please:
-
-1. Fork the repository
-2. Create a feature branch
-3. Add tests for new functionality
-4. Ensure all AWS module names are verified against actual AWS modules
-5. Submit a pull request
-
-## License
-
-This injector is released under the same license as OpenAEV. See the LICENSE file for details.
-
-## Support
-
-For issues and questions:
-- OpenAEV Documentation: https://docs.openaev.io
-- AWS Documentation: https://github.com/RhinoSecurityLabs/aws/wiki
-- Submit issues: https://github.com/OpenAEV-Platform/injectors/issues
-
-## Changelog
-
-### Recent Updates
-- Added support for 15+ additional AWS modules
-- Implemented AWS CLI integration for S3 operations
-- Expanded AWS regions support from 6 to 40+ regions
-- Fixed Windows compatibility issues with AWS session management
-- Improved error handling and reporting
-- Removed debug logging for production security
-- Optimized code structure with helper functions
+- Pacu documentation: [https://github.com/RhinoSecurityLabs/pacu/wiki](https://github.com/RhinoSecurityLabs/pacu/wiki)
+- AWS CLI documentation: [https://docs.aws.amazon.com/cli/](https://docs.aws.amazon.com/cli/)
+- Most contracts perform read-only enumeration; use "IAM Create User (Attack)" only against environments where creating
+  an IAM user is acceptable.

--- a/http-query/README.md
+++ b/http-query/README.md
@@ -1,148 +1,185 @@
-# OpenAEV Http Query Injector
+# OpenAEV HTTP Query Injector
 
-Table of Contents
+The HTTP Query injector lets OpenAEV perform arbitrary HTTP requests as part of attack scenarios. It exposes ready-to-use
+inject contracts (GET, POST and PUT, with a raw or key/value body), supports optional basic authentication, custom
+headers and file attachments, sends the request with the Python [requests](https://requests.readthedocs.io/) library,
+and reports the response status back to OpenAEV.
 
-- [OpenAEV Http Query Injector](#openaev-http-query-injector)
-    - [Prerequisites](#prerequisites)
-    - [Configuration variables](#configuration-variables)
-        - [OpenAEV environment variables](#openaev-environment-variables)
-        - [Base injector environment variables](#base-injector-environment-variables)
-    - [Deployment](#deployment)
-        - [Docker Deployment](#docker-deployment)
-        - [Manual Deployment](#manual-deployment)
-    - [Behavior](#behavior)
+## Table of Contents
 
-## Prerequisites
+- [OpenAEV HTTP Query Injector](#openaev-http-query-injector)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [How it works](#how-it-works)
+  - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenAEV environment variables](#openaev-environment-variables)
+    - [Base injector environment variables](#base-injector-environment-variables)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+  - [Inject contracts](#inject-contracts)
+  - [Target selection](#target-selection)
+  - [Behavior](#behavior)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
 
-Injectors are reaching RabbitMQ based the RabbitMQ configuration provided by the OpenAEV platform. The
-injector must be able to reach RabbitMQ on the specified hostname and port.
+## Introduction
+
+OpenAEV (Breach and Attack Simulation) drives injectors to execute the technical actions of a scenario. The HTTP Query
+injector registers a set of HTTP request contracts with the OpenAEV platform; when an inject using one of these contracts
+is played, OpenAEV dispatches a job to the injector, which performs the corresponding HTTP request and returns the result.
+
+## How it works
+
+Injectors receive their jobs through the message broker (RabbitMQ) configured by the OpenAEV platform. The injector
+fetches the broker connection details from OpenAEV at startup, so it only needs to be able to reach the OpenAEV URL and
+the RabbitMQ host/port advertised by the platform.
+
+## Requirements
+
+- A running OpenAEV platform, reachable from the injector (along with its RabbitMQ broker).
+- The injector also needs network access to the URLs it is asked to call.
+- No additional system binaries are required: the HTTP requests are made with the Python `requests` library.
+- The Docker image must be built with `--build-context injector_common=../injector_common`, because the injector depends
+  on the shared `injector_common` package located one level above this directory.
+- For a manual (non-Docker) deployment:
+  - Python >= 3.11 and [Poetry](https://python-poetry.org/) >= 2.1.
 
 ## Configuration variables
 
-There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or
-in `config.yml` (for manual deployment).
+The injector is configured either through environment variables (recommended, read from `docker-compose.yml` / the
+`.env` file for a Docker deployment) or through a `config.yml` file (for a manual deployment). Copy the provided
+`.env.sample` / `config.yml.sample` and fill in the values flagged with `ChangeMe`.
 
 ### OpenAEV environment variables
 
-Below are the parameters you'll need to set for OpenAEV:
-
-| Parameter         | config.yml | Docker environment variable | Mandatory | Description                                           |
-|-------------------|------------|-----------------------------|-----------|-------------------------------------------------------|
-| OpenAEV URL       | url        | `OPENAEV_URL`               | Yes       | The URL of the OpenAEV platform.                      |
-| OpenAEV Token     | token      | `OPENAEV_TOKEN`             | Yes       | The default admin token set in the OpenAEV platform.  |
-| OpenAEV Tenant ID | tenant_id  | `OPENAEV_TENANT_ID`         | No        | Identifier of the tenant within the OpenAEV platform. |
-
-> ⚠️ Warning ⚠️
->
-> The `tenant_id` parameter is a new configuration option. A period of backward compatibility is ensured: if this key is not defined,
-> existing configurations will not be affected, and the default value will be `None`. However, if a value is provided, it will be
-> validated by Pydantic and must conform to a valid UUID format, otherwise, a validation error will be returned.
+| Parameter         | config.yml          | Docker environment variable | Mandatory | Description                                                                        |
+|-------------------|---------------------|-----------------------------|-----------|------------------------------------------------------------------------------------|
+| OpenAEV URL       | `openaev.url`       | `OPENAEV_URL`               | Yes       | The URL of the OpenAEV platform. Must be reachable from where the injector runs.   |
+| OpenAEV Token     | `openaev.token`     | `OPENAEV_TOKEN`             | Yes       | The administrator token of the OpenAEV platform.                                   |
+| OpenAEV Tenant ID | `openaev.tenant_id` | `OPENAEV_TENANT_ID`         | No        | Tenant identifier for multi-tenant deployments. When set, it must be a valid UUID. |
 
 ### Base injector environment variables
 
-Below are the parameters you'll need to set for running the injector properly:
-
-| Parameter        | config.yml | Docker environment variable | Default    | Mandatory | Description                                                                            |
-|------------------|------------|-----------------------------|------------|-----------|----------------------------------------------------------------------------------------|
-| Injector ID      | id         | `INJECTOR_ID`               | /          | Yes       | A unique `UUIDv4` identifier for this injector instance.                               |
-| Collector Name   | name       | `INJECTOR_NAME`             | HTTP query | Yes       | Name of the injector.                                                                  |
-| Log Level        | log_level  | `INJECTOR_LOG_LEVEL`        | error      | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`. |
+| Parameter     | config.yml           | Docker environment variable | Default    | Mandatory | Description                                                     |
+|---------------|----------------------|-----------------------------|------------|-----------|-----------------------------------------------------------------|
+| Injector ID   | `injector.id`        | `INJECTOR_ID`               | /          | Yes       | A unique `UUIDv4` identifier for this injector instance.        |
+| Injector Name | `injector.name`      | `INJECTOR_NAME`             | HTTP query | No        | The name of the injector as shown in OpenAEV.                   |
+| Log Level     | `injector.log_level` | `INJECTOR_LOG_LEVEL`        | error      | No        | Verbosity of the logs. One of `debug`, `info`, `warn`, `error`. |
 
 ## Deployment
 
 ### Docker Deployment
 
-Build a Docker Image using the provided `Dockerfile`.
-
-Example:
+This injector depends on the shared `injector_common` package, so the image must be built with a build context that
+exposes it:
 
 ```shell
-# Replace the IMAGE NAME with the appropriate value
-docker build --build-context injector_common=../injector_common . -t [IMAGE NAME]:latest
+docker build --build-context injector_common=../injector_common . -t openaev/injector-http-query:latest
 ```
 
-Make sure to replace the environment variables in `docker-compose.yml` with the appropriate configurations for your
-environment. Then, start the docker container with the provided docker-compose.yml
+Create a `.env` file from `.env.sample` and fill in your values, then start the injector with the provided
+`docker-compose.yml`:
 
 ```shell
 docker compose up -d
-# -d for detached
 ```
 
----
-
-#### Domain name resolution - Local openAEV with Injector container
-**Note:** If you are running OpenAEV locally on your host machine and want to run this injector inside a Docker container, the `openaev` URL defined in `config.yml` and `.env` must be reachable from inside the container.
-
-Inside a container, `localhost` refers to the container itself - not your host machine. Therefore, you cannot use `localhost` as the OpenAEV URL unless OpenAEV is running inside the same container.
-
-Instead, use: `host.docker.internal`. This hostname allows the container to access services running on your host machine.
-
-**In short**:
-- `localhost` -> container itself
-- `host.docker.internal` -> your host machine
-
-**Platform-specific notes**:
-- **macOS / Windows (Docker Desktop):**     
-  `host.docker.internal` works out of the box. No additional configuration is needed.
-- **Linux:**  
-  You must explicitly map it using `extra_hosts`:
-```yaml
-services:
-  your-injector-name:
-    image: your-image-name
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-```
-
-**Important**:
-- Avoid mapping `host.docker.internal` to a fixed IP (e.g. `1.2.3.4`) unless you have a specific reason. The host IP can change, and Docker provides `host-gateway` to handle this dynamically.
-- Make sure your OpenAEV service is listening on `0.0.0.0` (not just `localhost`), otherwise it may NOT be accessible from the container.
-
----
+> If OpenAEV runs on your host machine while the injector runs in a container, set `OPENAEV_URL` to
+> `http://host.docker.internal:<port>` rather than `localhost`. On Linux, also add
+> `extra_hosts: ["host.docker.internal:host-gateway"]` to the service, and make sure OpenAEV listens on `0.0.0.0`.
 
 ### Manual Deployment
 
-Create a file `config.yml` based on the provided `config.yml.sample`.
-
-Replace the configuration variables with the appropriate configurations for
-you environment.
-
-The poetry package management system (version 2.1 or later) must also be available: https://python-poetry.org/
-
-Install the environment:
-
-**Production**:
-```shell
-# production environment
-poetry install 
-```
-
-**Development** (note that you should also clone the [pyoaev](OpenAEV-Platform/client-python) repository [according to
-these instructions](../README.md#simultaneous-development-on-pyoaev-and-an-injector))
-```shell
-# development environment
-poetry install --extras dev
-```
-
-Then, start the collector:
+Create a `config.yml` from `config.yml.sample`, then install and run the injector:
 
 ```shell
+poetry install
 poetry run python -m http_query.openaev_http
 ```
 
+> For local development against a checkout of [client-python](https://github.com/OpenAEV-Platform/client-python)
+> (cloned next to this repository), use `poetry install --extras dev`.
 
-## Behavior
+## Usage
 
-This injector enables new inject contracts, allowing for API calls of the Get, Post, and Put types.
+Once started, the injector registers its contracts with OpenAEV and waits for jobs. Add an HTTP Request inject to a
+scenario or atomic testing, choose the method (GET, POST or PUT), set the URL and any optional authentication, headers,
+body or attachments, then play it: the response status is attached to the inject once the request completes.
 
-### Passing headers with the request
-The contracts created in OpenAEV include an optional "Headers" parameter. While this field is technically a free-form
-text input, the contents passed to it are expected to be in a certain format: `key=value` and together separated with a comma  `,`.
+The fields available across the contracts are:
 
-Note the pattern supports whitespace within the keys and values.
+| Field                      | Content key     | Mandatory                       | Description                                                                  |
+|----------------------------|-----------------|---------------------------------|------------------------------------------------------------------------------|
+| URL                        | `uri`           | Yes                             | The target URL of the request.                                               |
+| Use basic authentication   | `basicAuth`     | No                              | Enables HTTP basic authentication.                                           |
+| Username                   | `basicUser`     | When basic auth is enabled      | Basic-auth username.                                                         |
+| Password                   | `basicPassword` | When basic auth is enabled      | Basic-auth password.                                                         |
+| Headers                    | `headers`       | No                              | Custom request headers (see format below).                                   |
+| Raw request data           | `body`          | Yes (raw-body contracts)        | Raw request body sent as-is.                                                 |
+| Form request data          | `parts`         | No (key/value contracts)        | Form fields sent as a key/value body (see format below).                     |
+| Attachments                | `attachments`   | No (key/value contracts)        | Inject documents sent as multipart file uploads.                             |
 
-Example:
+Headers are expressed as `key=value` pairs separated by commas (whitespace inside keys and values is preserved):
+
 ```plaintext
 content-type=application/json,x-custom-header=value for the header
 ```
+
+Form request data (the key/value body) is expressed as `key=value` pairs separated by `&`:
+
+```plaintext
+field1=value1&field2=value2
+```
+
+## Inject contracts
+
+All contracts share the label "HTTP Request" and the `WEB_APP` security domain. Each one returns the final request URL
+as a structured output.
+
+| Contract                          | HTTP method | Body                                                    |
+|-----------------------------------|-------------|---------------------------------------------------------|
+| HTTP Request - GET                | GET         | None                                                    |
+| HTTP Request - POST (raw body)    | POST        | Raw body from the `body` field                          |
+| HTTP Request - PUT (raw body)     | PUT         | Raw body from the `body` field                          |
+| HTTP Request - POST (key/value)   | POST        | Form key/value body from `parts` (+ optional attachments) |
+| HTTP Request - PUT (key/value)    | PUT         | Form key/value body from `parts` (+ optional attachments) |
+
+For the POST and PUT contracts, any inject documents flagged as attached are downloaded from OpenAEV and sent as
+multipart file uploads alongside the body.
+
+## Target selection
+
+This injector does not target OpenAEV assets. The "target" of every inject is the URL provided in the `uri` field, so
+there is no asset / asset-group / manual selector and no target-property mapping. Point the request at any endpoint
+reachable from where the injector runs.
+
+## Behavior
+
+```mermaid
+flowchart LR
+    O[OpenAEV inject] -->|job via RabbitMQ| I(HTTP Query injector)
+    I -->|GET / POST / PUT| U[Target URL]
+    U -->|HTTP response| I
+    I -->|status + response URL| O
+```
+
+On each job the injector acknowledges reception, builds a `requests` session (adding basic auth and headers when set),
+sends the GET, POST or PUT request for the selected contract, and returns the response (final URL and body) together with
+a success or error status.
+
+## Debugging
+
+Set `INJECTOR_LOG_LEVEL=debug` to get more verbose logs. Common issues:
+
+- Connection or DNS errors: confirm the target URL is reachable from where the injector runs.
+- Unexpected `400`/`401`/`405` responses: re-check the method, the headers format (`key=value` comma-separated) and the
+  basic-auth credentials.
+
+## Additional information
+
+- Contracts cover GET, POST and PUT; both a raw body and a key/value (form) body are supported for POST and PUT.
+- The structured output of each inject is the final request URL; the full response body is returned in the execution
+  message.

--- a/netexec/README.md
+++ b/netexec/README.md
@@ -1,272 +1,229 @@
 # OpenAEV NetExec Injector
 
+The NetExec injector lets OpenAEV run network execution and credential-testing actions as part of attack scenarios using
+[NetExec](https://www.netexec.wiki/) (the maintained successor to CrackMapExec). It exposes inject contracts across many
+protocols (SMB, SSH, LDAP, WinRM, MSSQL, RDP, VNC, FTP, WMI and NFS), resolves the targets from your OpenAEV assets or
+from manual input, builds and runs the corresponding `netexec` command, and reports the output (and structured findings)
+back to OpenAEV.
+
 ## Table of Contents
 
 - [OpenAEV NetExec Injector](#openaev-netexec-injector)
-    - [Prerequisites](#prerequisites)
-    - [Configuration variables](#configuration-variables)
-        - [OpenAEV environment variables](#openaev-environment-variables)
-        - [Base injector environment variables](#base-injector-environment-variables)
-    - [Deployment](#deployment)
-        - [Docker Deployment](#docker-deployment)
-        - [Manual Deployment](#manual-deployment)
-    - [Behavior](#behavior)
-    - [Supported Contracts](#supported-contracts)
-    - [Target Selection](#target-selection)
-    - [Resources](#resources)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [How it works](#how-it-works)
+  - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenAEV environment variables](#openaev-environment-variables)
+    - [Base injector environment variables](#base-injector-environment-variables)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+  - [Inject contracts](#inject-contracts)
+  - [Target selection](#target-selection)
+  - [Behavior](#behavior)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
 
----
+## Introduction
 
-## Prerequisites
+OpenAEV (Breach and Attack Simulation) drives injectors to execute the technical actions of a scenario. The NetExec
+injector registers a large set of protocol contracts with the OpenAEV platform; when an inject using one of these
+contracts is played, OpenAEV dispatches a job to the injector, which builds and runs the matching NetExec command
+against the resolved targets and returns the results.
 
-This injector uses [NetExec](https://www.netexec.wiki/).
+## How it works
 
-This injector communicates with the OpenAEV platform through **RabbitMQ**, using the configuration provided by OpenAEV.
+Injectors receive their jobs through the message broker (RabbitMQ) configured by the OpenAEV platform. The injector
+fetches the broker connection details from OpenAEV at startup, so it only needs to be able to reach the OpenAEV URL and
+the RabbitMQ host/port advertised by the platform.
 
-To function properly, the injector **must be able to reach the RabbitMQ service** (hostname and port) defined in the
-OpenAEV configuration.
+## Requirements
 
-## Configuration
+- A running OpenAEV platform, reachable from the injector (along with its RabbitMQ broker).
+- The `netexec` binary must be available on the `PATH`. The Docker image installs it from source
+  (`pip install git+https://github.com/Pennyw0rth/NetExec.git`); the image build also pulls the toolchain NetExec needs
+  to compile its native dependencies (`gcc`, `musl-dev`, `libffi-dev`, `openssl-dev`, `cargo`, `git`).
+- The Docker image must be built with `--build-context injector_common=../injector_common`, because the injector depends
+  on the shared `injector_common` package located one level above this directory.
+- For a manual (non-Docker) deployment:
+  - Python >= 3.11 and [Poetry](https://python-poetry.org/) >= 2.1.
+  - NetExec installed and reachable as `netexec` (see
+    [the NetExec installation guide](https://www.netexec.wiki/getting-started/installation)).
 
-Configuration values can be provided either:
+## Configuration variables
 
-* via `docker-compose.yml` (Docker deployment), or
-* via `config.yml` (manual deployment).
+The injector is configured either through environment variables (recommended, read from `docker-compose.yml` / the
+`.env` file for a Docker deployment) or through a `config.yml` file (for a manual deployment). Copy the provided
+`.env.sample` / `config.yml.sample` and fill in the values flagged with `ChangeMe`.
 
-### OpenAEV Environment Variables
+### OpenAEV environment variables
 
-The following parameters are required to connect the injector to the OpenAEV platform:
+| Parameter         | config.yml          | Docker environment variable | Mandatory | Description                                                                        |
+|-------------------|---------------------|-----------------------------|-----------|------------------------------------------------------------------------------------|
+| OpenAEV URL       | `openaev.url`       | `OPENAEV_URL`               | Yes       | The URL of the OpenAEV platform. Must be reachable from where the injector runs.   |
+| OpenAEV Token     | `openaev.token`     | `OPENAEV_TOKEN`             | Yes       | The administrator token of the OpenAEV platform.                                   |
+| OpenAEV Tenant ID | `openaev.tenant_id` | `OPENAEV_TENANT_ID`         | No        | Tenant identifier for multi-tenant deployments. When set, it must be a valid UUID. |
 
-| Parameter         | `config.yml` | Docker Variable     | Mandatory | Description                                           |
-|-------------------|--------------|---------------------|-----------|-------------------------------------------------------|
-| OpenAEV URL       | `url`        | `OPENAEV_URL`       | Yes       | Base URL of the OpenAEV platform.                     |
-| OpenAEV Token     | `token`      | `OPENAEV_TOKEN`     | Yes       | Admin API token configured in the OpenAEV platform.   |
-| OpenAEV Tenant ID | `tenant_id`  | `OPENAEV_TENANT_ID` | No        | Identifier of the tenant within the OpenAEV platform. |
+### Base injector environment variables
 
-> ⚠️ Warning ⚠️
->
-> The `tenant_id` parameter is a new configuration option. A period of backward compatibility is ensured: if this key is not defined,
-> existing configurations will not be affected, and the default value will be `None`. However, if a value is provided, it will be
-> validated by Pydantic and must conform to a valid UUID format, otherwise, a validation error will be returned.
+| Parameter     | config.yml           | Docker environment variable | Default | Mandatory | Description                                                     |
+|---------------|----------------------|-----------------------------|---------|-----------|-----------------------------------------------------------------|
+| Injector ID   | `injector.id`        | `INJECTOR_ID`               | /       | Yes       | A unique `UUIDv4` identifier for this injector instance.        |
+| Injector Name | `injector.name`      | `INJECTOR_NAME`             | NetExec | No        | The name of the injector as shown in OpenAEV.                   |
+| Log Level     | `injector.log_level` | `INJECTOR_LOG_LEVEL`        | info    | No        | Verbosity of the logs. One of `debug`, `info`, `warn`, `error`. |
 
-### Injector Environment Variables
-
-The following parameters control the injector runtime behavior:
-
-| Parameter     | `config.yml` | Docker Variable      | Default   | Mandatory | Description                                             |
-|---------------|--------------|----------------------|-----------|-----------|---------------------------------------------------------|
-| Injector ID   | `id`         | `INJECTOR_ID`        | —         | Yes       | Unique `UUIDv4` identifying this injector instance.     |
-| Injector Name | `name`       | `INJECTOR_NAME`      | `NetExec` | Yes       | Human-readable name of the injector.                    |
-| Log Level     | `log_level`  | `INJECTOR_LOG_LEVEL` | `info`    | Yes       | Logging verbosity: `debug`, `info`, `warn`, or `error`. |
+Credentials supplied per inject (usernames, passwords, hashes, domains, key files) are never written to the logs: they
+are redacted before any logging or callback message is sent.
 
 ## Deployment
 
 ### Docker Deployment
 
-Build the Docker image using the provided `Dockerfile`.
+This injector depends on the shared `injector_common` package, so the image must be built with a build context that
+exposes it:
 
 ```shell
 docker build --build-context injector_common=../injector_common . -t openaev/injector-netexec:latest
 ```
 
-Then configure the environment variables in `docker-compose.yml` and start the injector:
+Create a `.env` file from `.env.sample` and fill in your values, then start the injector with the provided
+`docker-compose.yml`:
 
 ```shell
 docker compose up -d
 ```
 
-> The Docker image **already contains NetExec**. No further installation is needed inside the container.
+> The Docker image already bundles NetExec, so no further installation is needed inside the container.
+
+> If OpenAEV runs on your host machine while the injector runs in a container, set `OPENAEV_URL` to
+> `http://host.docker.internal:<port>` rather than `localhost`. On Linux, also add
+> `extra_hosts: ["host.docker.internal:host-gateway"]` to the service, and make sure OpenAEV listens on `0.0.0.0`.
 
 ### Manual Deployment
 
-1. Create a `config.yml` file based on `config.yml.sample`
-2. Adjust the configuration values to match your environment
-
-#### Prerequisites
-
-* **NetExec must be installed locally** and accessible via the command line (`netexec` command).
-* You can install it
-  from: [https://www.netexec.wiki/getting-started/installation](https://www.netexec.wiki/getting-started/installation)
-
-* Python package manager **Poetry** (version 2.1 or later)
-
-#### Installation
-
-**Production environment**
+Make sure `netexec` is installed and on your `PATH`, create a `config.yml` from `config.yml.sample`, then install and
+run the injector:
 
 ```shell
-poetry install --extras prod
-```
-
-**Development environment**
-
-For development, you should also clone the `pyoaev` repository following the instructions provided in the OpenAEV
-documentation.
-
-```shell
-poetry install --extras dev
-```
-
-## Development
-
-Before submitting any **Pull Request**, contributors **must** format the codebase using **isort** and **black**.
-
-```shell
-poetry run isort --profile black .
-poetry run black .
-```
-
-#### Run the Injector
-
-```shell
+poetry install
 poetry run python -m netexec.openaev_netexec
 ```
 
+> For local development against a checkout of [client-python](https://github.com/OpenAEV-Platform/client-python)
+> (cloned next to this repository), use `poetry install --extras dev`.
+
+## Usage
+
+Once started, the injector registers its contracts with OpenAEV and waits for jobs. Add a NetExec inject to a scenario
+or atomic testing, pick the protocol contract (and, if relevant, the option or module variant), set the targets and the
+credentials, then play it: the command output and structured findings are attached to the inject once it completes.
+
+At startup the injector logs the detected NetExec version (`netexec --version`).
+
+## Inject contracts
+
+Contracts are generated for each supported protocol and come in three families. The contract ID encodes the family:
+
+- `netexec_<protocol>` - base protocol contract (the bare authentication check, optionally with a command to execute).
+- `netexec_<protocol>_opt_<option_id>` - protocol + option contract (adds one NetExec flag, e.g. `--shares`).
+- `netexec_<protocol>_mod_<module>` - protocol + module contract (runs a NetExec module with `-M <module>`).
+
+All contracts share the label prefix "NetExec" and the `ENDPOINT` / `NETWORK` security domains. Every contract also
+exposes the shared target selector, the protocol credentials, an optional `port` override, and expectations. The
+following protocols are available:
+
+| Protocol | Default port | Credentials accepted                | Command-execution fields                          | Number of option contracts |
+|----------|--------------|-------------------------------------|---------------------------------------------------|-----------------------------|
+| SMB      | 445          | username, password, NTLM hash, domain | `-x` (command), `-X` (PowerShell)               | 14                          |
+| SSH      | 22           | username, password, SSH key file      | `-x` (command)                                  | 2                           |
+| LDAP     | 389          | username, password, NTLM hash, domain | -                                               | 14                          |
+| WinRM    | 5985         | username, password, NTLM hash, domain | `-x` (command), `-X` (PowerShell)               | 4                           |
+| MSSQL    | 1433         | username, password, NTLM hash, domain | `-q` (SQL), `-x` (command), `-X` (PowerShell)   | 3                           |
+| RDP      | 3389         | username, password, NTLM hash, domain | `-x` (command), `-X` (PowerShell)               | 3                           |
+| VNC      | 5900         | password                              | -                                               | 1                           |
+| FTP      | 21           | username, password                    | -                                               | 1                           |
+| WMI      | 135          | username, password, NTLM hash, domain | `-x` (command), `-X` (PowerShell), `--wmi-query` | 2                          |
+| NFS      | 111          | -                                     | -                                               | 3                           |
+
+Option contracts add a single flag on top of the base protocol contract. The available options per protocol are:
+
+- SMB: `--shares`, `--pass-pol`, `--users`, `--groups`, `--local-groups`, `--loggedon-users`, `--computers`,
+  `--rid-brute`, `--disks`, `--interfaces`, `--local-auth`, `--sam`, `--lsa`, `--ntds`
+- SSH: `--sudo-check`, `--no-output`
+- LDAP: `--users`, `--groups`, `--computers`, `--dc-list`, `--get-sid`, `--active-users`, `--trusted-for-delegation`,
+  `--find-delegation`, `--password-not-required`, `--admin-count`, `--gmsa`, `--asreproast`, `--kerberoasting`,
+  `--bloodhound`
+- WinRM: `--local-auth`, `--sam`, `--lsa`, `--no-output`
+- MSSQL: `--local-auth`, `--rid-brute`, `--no-output`
+- RDP: `--local-auth`, `--screenshot`, `--nla-screenshot`
+- VNC: `--screenshot`
+- FTP: `--ls`
+- WMI: `--local-auth`, `--no-output`
+- NFS: `--shares`, `--enum-shares`, `--ls`
+
+> The `--asreproast` and `--kerberoasting` LDAP options write their results to an auto-generated temporary file, which is
+> read back into the inject output and then removed.
+
+Module contracts wrap the NetExec module catalogue (`add-computer`, `lsassy`, `ntdsutil`, `spider_plus`, `zerologon`,
+`ms17-010`, ...). One contract is generated per (protocol, module) pair the module supports, and each module exposes its
+own option fields (mapped to `-o KEY=VALUE`) plus a free-text "Additional module options" field. Because there are many
+such combinations, browse them directly in OpenAEV rather than listing every one here.
+
+The command the injector builds follows this shape:
+
+```shell
+netexec <protocol> <targets> [-u <user>] [-p <password>] [-H <hash>] [-d <domain>] [--key-file <path>] \
+        [--port <port>] [<option flag>] [-x "<command>"] [-M <module> -o KEY=VALUE ...]
+```
+
+## Target selection
+
+Targets are resolved through the shared selection logic of `injector_common`:
+
+- Target selector: `assets`, `asset-groups` (default), or `manual`.
+- Target property selector (for assets / asset groups): `automatic` (default), `seen_ip`, `local_ip` (first), or
+  `hostname`.
+
+| Target property   | Asset field used                                   |
+|-------------------|----------------------------------------------------|
+| Automatic         | Hostname for agentless assets, else first valid IP |
+| Seen IP           | `endpoint_seen_ip`                                 |
+| Local IP (first)  | First valid entry in `endpoint_ips`                |
+| Hostname          | `endpoint_hostname`                                |
+
+For manual targets, provide hostnames or IP addresses as comma-separated values. Invalid, loopback and link-local
+addresses are filtered out.
+
 ## Behavior
 
-The NetExec injector performs **contract-based network reconnaissance and authentication checks** by dynamically
-building and executing **NetExec commands** based on the contract configuration and user inputs.
-
-Each execution translates contract fields (targets, credentials, and options) into a NetExec command and runs it against
-the selected targets.
-
-## Supported Contracts
-
-The injector supports **10 protocols** via dedicated contracts:
-
-| Contract | Protocol | Default Port | Authentication | Command Execution |
-|----------|----------|--------------|----------------|-------------------|
-| **NetExec - SMB** | SMB | 445 | username, password, NTLM hash, domain | `-x` (CMD), `-X` (PowerShell) |
-| **NetExec - SSH** | SSH | 22 | username, password, SSH key file | `-x` (CMD) |
-| **NetExec - LDAP** | LDAP | 389 | username, password, NTLM hash, domain | — |
-| **NetExec - WinRM** | WinRM | 5985 | username, password, NTLM hash, domain | `-x` (CMD), `-X` (PowerShell) |
-| **NetExec - MSSQL** | MSSQL | 1433 | username, password, NTLM hash, domain | `-x` (CMD), `-X` (PowerShell), `-q` (SQL) |
-| **NetExec - RDP** | RDP | 3389 | username, password, NTLM hash, domain | `-x` (CMD), `-X` (PowerShell) |
-| **NetExec - VNC** | VNC | 5900 | password | — |
-| **NetExec - FTP** | FTP | 21 | username, password | — |
-| **NetExec - WMI** | WMI | 135 | username, password, NTLM hash, domain | `-x` (CMD), `-X` (PowerShell), WMI query |
-| **NetExec - NFS** | NFS | 111 | — (host-based) | — |
-
-### Per-protocol options
-
-**SMB**: `--shares`, `--users`, `--groups`, `--local-groups`, `--sessions`, `--loggedon-users`, `--computers`, `--rid-brute`, `--disks`, `--interfaces`, `--pass-pol`, `--local-auth`, `--sam`, `--lsa`, `--ntds`
-
-**SSH**: `--sudo-check`, `--no-output`
-
-**LDAP**: `--users`, `--groups`, `--computers`, `--dc-list`, `--get-sid`, `--active-users`, `--pass-pol`, `--pso`, `--trusted-for-delegation`, `--find-delegation`, `--password-not-required`, `--admin-count`, `--gmsa`, `--asreproast`, `--kerberoasting`, `--bloodhound`
-
-**WinRM**: `--local-auth`, `--sam`, `--lsa`, `--dpapi`, `--no-output`
-
-**MSSQL**: `--local-auth`, `--sam`, `--lsa`, `--rid-brute`, `--no-output`
-
-**RDP**: `--local-auth`, `--screenshot`, `--nla-screenshot`, `--no-output`
-
-**VNC**: `--screenshot`
-
-**FTP**: `--ls`
-
-**WMI**: `--local-auth`, `--no-output`
-
-**NFS**: `--shares`, `--enum-shares`, `--ls`
-
-## Structured Output Parsing
-
-The injector extracts structured findings from NetExec command output. Each contract can produce multiple finding types beyond raw text.
-
-### Finding Types
-
-| Output Type | Field | Description | Mandatory Fields |
-|---|---|---|---|
-| `text` | `text` | Raw text output lines | — |
-| `credentials` | `credentials` | Reusable credentials (passwords, NTLM hashes) | `username` + (`password` or `hash`) |
-| `username` | `usernames` | Enumerated user accounts | `username` |
-| `admin_username` | `admin_usernames` | Admin accounts (adminCount=1) | `username` |
-| `share` | `shares` | SMB shares (excludes admin shares ending with `$`) | `share_name` + `permissions` |
-| `group` | `groups` | AD / local groups | `group_name` |
-| `computer` | `computers` | Computer accounts | `computer_name` |
-| `password_policy` | `password_policy` | Domain password policy settings | `key` + `value` |
-| `delegation` | `delegations` | Kerberos delegation configurations | `account` |
-| `sid` | `sids` | Domain SID | `sid` |
-| `vulnerability` | `vulnerabilities` | Vulnerability detection results | `name` + `status` |
-| `account_with_password_not_required` | `accounts_pw_not_required` | Accounts with PASSWD_NOTREQD flag | `account` |
-| `asreproastable_account` | `asreproastable_accounts` | AS-REP roastable accounts | `username` |
-| `kerberoastable_account` | `kerberoastable_accounts` | Kerberoastable accounts | `username` |
-
-### Contracts with Dedicated Output Parsers
-
-| Contract | Finding Types Extracted |
-|---|---|
-| `--users` (SMB/LDAP) | credentials, usernames |
-| `--active-users` (LDAP) | usernames |
-| `--rid-brute` (SMB) | usernames (SidTypeUser only) |
-| `--loggedon-users` (SMB) | usernames |
-| `--admin-count` (LDAP) | admin_usernames |
-| `--shares` (SMB) | shares |
-| `--groups` (LDAP) | groups (with member count) |
-| `--local-groups` (SMB) | groups (with RID) |
-| `--computers` (LDAP) | computers |
-| `--pass-pol` (SMB) | password_policy |
-| `--trusted-for-delegation` (LDAP) | delegations |
-| `--find-delegation` (LDAP) | delegations (with type and rights) |
-| `--get-sid` (LDAP) | sids |
-| `--password-not-required` (LDAP) | accounts_pw_not_required |
-| `--asreproast` (LDAP) | asreproastable_accounts |
-| `--kerberoasting` (LDAP) | kerberoastable_accounts |
-| `--sam` (SMB) | credentials (NTLM hashes) |
-| `--lsa` (SMB) | credentials (Kerberos keys, NTLM, cleartext) |
-| `--ntds` (SMB) | credentials (NTLM hashes) |
-| `-M dpapi_hash` (SMB) | credentials (DPAPI master key hashes) |
-| `-M get_desc_users` (LDAP) | credentials (passwords in descriptions) |
-| `-M user_desc` (SMB) | credentials (passwords in descriptions) |
-| `-M spooler` (SMB) | vulnerabilities |
-| `-M coerce_plus` (SMB) | vulnerabilities |
-| `-M ldap-checker` (LDAP) | vulnerabilities |
-
-> Contracts without a dedicated parser still produce `text` findings from their raw output.
-
-## Target Selection
-
-Targets are resolved using the `target_selector` field defined in the contract.
-
-### When the target type is **Assets**
-
-| Selected Property | Asset Field Used              |
-|-------------------|-------------------------------|
-| Seen IP           | `endpoint_seen_ip`            |
-| Local IP          | First entry in `endpoint_ips` |
-| Hostname          | `endpoint_hostname`           |
-
-### When the target type is **Manual**
-
-Targets are provided directly as **comma-separated IP addresses or hostnames**.
-
-## Example Executions
-
-SMB share enumeration:
-
-```bash
-netexec smb 192.168.1.50 --shares
+```mermaid
+flowchart LR
+    O[OpenAEV inject] -->|job via RabbitMQ| I(NetExec injector)
+    I -->|resolve targets| T[Assets / Asset groups / Manual]
+    I -->|netexec proto targets ...| N[NetExec]
+    N -->|stdout| P[Output parser]
+    P -->|structured findings| I
+    I -->|results and status| O
 ```
 
-SSH authentication with command execution:
+On each job the injector acknowledges reception, resolves the targets, parses the contract ID into protocol/family/
+option-or-module, builds the NetExec command (with redacted credentials reported in the command-execution callback),
+runs it (5-minute timeout), parses the output into structured findings, and returns a success or error status.
 
-```bash
-netexec ssh 192.168.1.50 -u admin -p Password123 -x "whoami"
-```
+## Debugging
 
-LDAP user enumeration:
+Set `INJECTOR_LOG_LEVEL=debug` to log the parsed contract and the (credential-redacted) command line. Common issues:
 
-```bash
-netexec ldap 192.168.1.10 -u admin -p Password123 -d CONTOSO --users
-```
+- `netexec` not found: for manual deployments, make sure NetExec is installed and on the `PATH`.
+- Connectivity / authentication failures: verify the target is reachable on the protocol port and that the supplied
+  credentials (and `--local-auth` where relevant) are correct.
+- A run that times out after 5 minutes returns an error message indicating the timeout.
 
-MSSQL SQL query:
+## Additional information
 
-```bash
-netexec mssql 192.168.1.20 -u sa -p Password123 --local-auth -q "SELECT name FROM sys.databases"
-```
-
-## Resources
-
-* [NetExec GitHub Repository](https://github.com/Pennyw0rth/NetExec)
-* [NetExec Documentation](https://www.netexec.wiki/)
+- NetExec documentation: [https://www.netexec.wiki/](https://www.netexec.wiki/)
+- NetExec source: [https://github.com/Pennyw0rth/NetExec](https://github.com/Pennyw0rth/NetExec)
+- Contracts come in three families (base protocol, protocol + option, protocol + module); the injector always invokes
+  the `netexec` binary.

--- a/nmap/README.md
+++ b/nmap/README.md
@@ -1,184 +1,163 @@
 # OpenAEV Nmap Injector
 
-Table of Contents
+The Nmap injector lets OpenAEV run network port scans as part of attack scenarios using
+[Nmap](https://nmap.org/), the open-source network mapper. It exposes ready-to-use inject contracts (SYN, TCP Connect
+and FIN scans), resolves the targets from your OpenAEV assets or from manual input, runs the scan, and reports the
+discovered open ports and services back to OpenAEV as structured results.
+
+## Table of Contents
 
 - [OpenAEV Nmap Injector](#openaev-nmap-injector)
-    - [Prerequisites](#prerequisites)
-    - [Configuration variables](#configuration-variables)
-        - [OpenAEV environment variables](#openaev-environment-variables)
-        - [Base injector environment variables](#base-injector-environment-variables)
-    - [Deployment](#deployment)
-        - [Docker Deployment](#docker-deployment)
-        - [Manual Deployment](#manual-deployment)
-    - [Behavior](#behavior)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [How it works](#how-it-works)
+  - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenAEV environment variables](#openaev-environment-variables)
+    - [Base injector environment variables](#base-injector-environment-variables)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+  - [Inject contracts](#inject-contracts)
+  - [Target selection](#target-selection)
+  - [Behavior](#behavior)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
 
-## Prerequisites
+## Introduction
 
-Injectors are reaching RabbitMQ based the RabbitMQ configuration provided by the OpenAEV platform. The
-injector must be able to reach RabbitMQ on the specified hostname and port.
+OpenAEV (Breach and Attack Simulation) drives injectors to execute the technical actions of a scenario. The Nmap
+injector registers a set of scan contracts with the OpenAEV platform; when an inject using one of these contracts is
+played, OpenAEV dispatches a job to the injector, which performs the corresponding Nmap scan and returns the results.
+
+## How it works
+
+Injectors receive their jobs through the message broker (RabbitMQ) configured by the OpenAEV platform. The injector
+fetches the broker connection details from OpenAEV at startup, so it only needs to be able to reach the OpenAEV URL and
+the RabbitMQ host/port advertised by the platform.
+
+## Requirements
+
+- OpenAEV Platform >= 1.19.0, reachable from the injector (along with its RabbitMQ broker)
+- For a manual (non-Docker) deployment:
+  - Python >= 3.11 and [Poetry](https://python-poetry.org/) >= 2.1
+  - The `nmap` and `jc` binaries available on the `PATH` (the Docker image already bundles them)
 
 ## Configuration variables
 
-There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or
-in `config.yml` (for manual deployment).
+The injector is configured either through environment variables (recommended, read from `docker-compose.yml` / the
+`.env` file for a Docker deployment) or through a `config.yml` file (for a manual deployment). Copy the provided
+`.env.sample` / `config.yml.sample` and fill in the values flagged with `ChangeMe`.
 
 ### OpenAEV environment variables
 
-Below are the parameters you'll need to set for OpenAEV:
-
-| Parameter          | config.yml | Docker environment variable | Mandatory | Description                                           |
-|--------------------|------------|-----------------------------|-----------|-------------------------------------------------------|
-| OpenAEV URL        | url        | `OPENAEV_URL`               | Yes       | The URL of the OpenAEV platform.                      |
-| OpenAEV Token      | token      | `OPENAEV_TOKEN`             | Yes       | The default admin token set in the OpenAEV platform.  |
-| OpenAEV Tenant ID  | tenant_id  | `OPENAEV_TENANT_ID`         | No        | Identifier of the tenant within the OpenAEV platform. |
-
-> ⚠️ Warning ⚠️
->
-> The `tenant_id` parameter is a new configuration option. A period of backward compatibility is ensured: if this key is not defined,
-> existing configurations will not be affected, and the default value will be `None`. However, if a value is provided, it will be
-> validated by Pydantic and must conform to a valid UUID format, otherwise, a validation error will be returned.
+| Parameter         | config.yml          | Docker environment variable | Mandatory | Description                                                                        |
+|-------------------|---------------------|-----------------------------|-----------|------------------------------------------------------------------------------------|
+| OpenAEV URL       | `openaev.url`       | `OPENAEV_URL`               | Yes       | The URL of the OpenAEV platform. Must be reachable from where the injector runs.   |
+| OpenAEV Token     | `openaev.token`     | `OPENAEV_TOKEN`             | Yes       | The administrator token of the OpenAEV platform.                                   |
+| OpenAEV Tenant ID | `openaev.tenant_id` | `OPENAEV_TENANT_ID`         | No        | Tenant identifier for multi-tenant deployments. When set, it must be a valid UUID. |
 
 ### Base injector environment variables
 
-Below are the parameters you'll need to set for running the injector properly:
-
-| Parameter      | config.yml | Docker environment variable | Default | Mandatory | Description                                                                            |
-|----------------|------------|-----------------------------|---------|-----------|----------------------------------------------------------------------------------------|
-| Injector ID    | id         | `INJECTOR_ID`               | /       | Yes       | A unique `UUIDv4` identifier for this injector instance.                               |
-| Collector Name | name       | `INJECTOR_NAME`             | Nmap    | Yes       | Name of the injector.                                                                  |
-| Log Level      | log_level  | `INJECTOR_LOG_LEVEL`        | error   | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`. |
+| Parameter     | config.yml           | Docker environment variable | Default | Mandatory | Description                                                     |
+|---------------|----------------------|-----------------------------|---------|-----------|-----------------------------------------------------------------|
+| Injector ID   | `injector.id`        | `INJECTOR_ID`               | /       | Yes       | A unique `UUIDv4` identifier for this injector instance.        |
+| Injector Name | `injector.name`      | `INJECTOR_NAME`             | Nmap    | No        | The name of the injector as shown in OpenAEV.                   |
+| Log Level     | `injector.log_level` | `INJECTOR_LOG_LEVEL`        | error   | No        | Verbosity of the logs. One of `debug`, `info`, `warn`, `error`. |
 
 ## Deployment
 
 ### Docker Deployment
 
-Build a Docker Image using the provided `Dockerfile`.
-
-Example:
+This injector depends on the shared `injector_common` package, so the image must be built with a build context that
+exposes it:
 
 ```shell
-# Replace the IMAGE NAME with the appropriate value
-docker build --build-context injector_common=../injector_common . -t [IMAGE NAME]:latest
+docker build --build-context injector_common=../injector_common . -t openaev/injector-nmap:latest
 ```
 
-Make sure to replace the environment variables in `docker-compose.yml` with the appropriate configurations for your
-environment. Then, start the docker container with the provided docker-compose.yml
+Create a `.env` file from `.env.sample` and fill in your values, then start the injector with the provided
+`docker-compose.yml`:
 
 ```shell
 docker compose up -d
-# -d for detached
 ```
 
----
-
-#### Domain name resolution - Local openAEV with Injector container
-**Note:** If you are running OpenAEV locally on your host machine and want to run this injector inside a Docker container, the `openaev` URL defined in `config.yml` and `.env` must be reachable from inside the container.
-
-Inside a container, `localhost` refers to the container itself - not your host machine. Therefore, you cannot use `localhost` as the OpenAEV URL unless OpenAEV is running inside the same container.
-
-Instead, use: `host.docker.internal`. This hostname allows the container to access services running on your host machine.
-
-**In short**:
-- `localhost` -> container itself
-- `host.docker.internal` -> your host machine
-
-**Platform-specific notes**:
-- **macOS / Windows (Docker Desktop):**     
-  `host.docker.internal` works out of the box. No additional configuration is needed.
-- **Linux:**  
-  You must explicitly map it using `extra_hosts`:
-```yaml
-services:
-  your-injector-name:
-    image: your-image-name
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-```
-
-**Important**:
-- Avoid mapping `host.docker.internal` to a fixed IP (e.g. `1.2.3.4`) unless you have a specific reason. The host IP can change, and Docker provides `host-gateway` to handle this dynamically.
-- Make sure your OpenAEV service is listening on `0.0.0.0` (not just `localhost`), otherwise it may NOT be accessible from the container.
-
----
+> If OpenAEV runs on your host machine while the injector runs in a container, set `OPENAEV_URL` to
+> `http://host.docker.internal:<port>` rather than `localhost`. On Linux, also add
+> `extra_hosts: ["host.docker.internal:host-gateway"]` to the service, and make sure OpenAEV listens on `0.0.0.0`.
 
 ### Manual Deployment
 
-#### Prerequisites
-
-The `nmap` and `jc` commands must be installed and available on the system you are running.
-
-The poetry package management system (version 2.1 or later) must also be available: https://python-poetry.org/
-Install the environment:
-
-**Production**:
-```shell
-# production environment
-poetry install 
-```
-
-**Development** (note that you should also clone the [pyoaev](OpenAEV-Platform/client-python) repository [according to
-these instructions](../README.md#simultaneous-development-on-pyoaev-and-an-injector))
-```shell
-# development environment
-poetry install --extras dev
-```
-
-Then, start the collector:
+Make sure `nmap` and `jc` are installed and on your `PATH`, create a `config.yml` from `config.yml.sample`, then install
+and run the injector:
 
 ```shell
+poetry install
 poetry run python -m nmap.openaev_nmap
 ```
 
+> For local development against a checkout of [client-python](https://github.com/OpenAEV-Platform/client-python)
+> (cloned next to this repository), use `poetry install --extras dev`.
+
+## Usage
+
+Once started, the injector registers its contracts with OpenAEV and waits for jobs. Add an Nmap inject to a scenario or
+atomic testing, select the scan type and the targets, and play it: the results are attached to the inject once the scan
+completes.
+
+## Inject contracts
+
+| Contract              | Scan type        | Command executed             |
+|-----------------------|------------------|------------------------------|
+| Nmap - SYN Scan       | TCP SYN scan     | `nmap -Pn -sS -oX - <targets>` |
+| Nmap - TCP Connect Scan | TCP connect scan | `nmap -Pn -sT -oX - <targets>` |
+| Nmap - FIN Scan       | TCP FIN scan     | `nmap -Pn -sF -oX - <targets>` |
+
+`-Pn` skips host discovery (treat all hosts as online). Nmap output is produced as XML (`-oX -`) and converted to JSON
+with `jc --xml -p` before being parsed into open ports and services.
+
+## Target selection
+
+Targets are resolved through the shared selection logic of `injector_common`:
+
+- Target selector: `assets`, `asset-groups` (default), or `manual`.
+- Target property selector (for assets / asset groups): `automatic` (default), `seen_ip`, `local_ip` (first), or
+  `hostname`.
+
+| Target property   | Asset field used                            |
+|-------------------|---------------------------------------------|
+| Automatic         | Hostname for agentless assets, else first valid IP |
+| Seen IP           | `endpoint_seen_ip`                          |
+| Local IP (first)  | First valid entry in `endpoint_ips`         |
+| Hostname          | `endpoint_hostname`                         |
+
+For manual targets, provide hostnames or IP addresses as comma-separated values. Invalid, loopback and link-local
+addresses are filtered out.
 
 ## Behavior
 
-The injector enables new inject contracts, supporting the following Nmap scan types:
-
-### Nmap - FIN Scan
-
-Command executed:
-
-```shell
-nmap -Pn -sF
+```mermaid
+flowchart LR
+    O[OpenAEV inject] -->|job via RabbitMQ| I(Nmap injector)
+    I -->|resolve targets| T[Assets / Asset groups / Manual]
+    I -->|nmap -Pn -sX -oX -| N[Nmap]
+    N -->|XML| J[jc --xml -p]
+    J -->|JSON| I
+    I -->|open ports and services| O
 ```
 
-### Nmap - SYN Scan
+On each job the injector acknowledges reception, resolves the targets, builds and runs the Nmap command, pipes the XML
+output through `jc` to JSON, parses the open ports and services, and returns a structured result (linked to the scanned
+asset when applicable) together with a success or error status.
 
-Command executed:
+## Debugging
 
-```shell
-nmap -Pn -sS
-```
+Set `INJECTOR_LOG_LEVEL=debug` to log the resolved targets and the exact Nmap command line that is executed. For manual
+deployments, the most common issue is a missing `nmap` or `jc` binary on the `PATH`.
 
-### Nmap - TCP Connect Scan
+## Additional information
 
-Command executed:
-
-```shell
-nmap -Pn -sT
-```
-
-### Target Selection
-
-The targets vary based on the provided options:
-
-If type of targets is Assets:
-
-| Targeted property | Asset property       | 
-|-------------------|----------------------|
-| Seen IP           | Seen IP address      |
-| Local IP (first)  | IP Addresses (first) |
-| Hostname          | Hostname             |
-
-If type of targets is Manual:
-
-- Hostnames or IP addresses are provided directly as comma-separated values.
-
-### Resources
-
-- Official Nmap Documentation: https://nmap.org/docs.html
-- Options Explanation:
-    - -Pn: Host Discovery
-    - -sS: SYN Scan
-    - -sT: TCP Connect Scan
-    - -sF: FIN Scan
+- Official Nmap documentation: [https://nmap.org/docs.html](https://nmap.org/docs.html)
+- Scan option reference: `-Pn` (skip host discovery), `-sS` (SYN scan), `-sT` (TCP connect scan), `-sF` (FIN scan).

--- a/nuclei/README.md
+++ b/nuclei/README.md
@@ -1,316 +1,222 @@
 # OpenAEV Nuclei Injector
 
+The Nuclei injector lets OpenAEV run template-based vulnerability scans as part of attack scenarios using
+[Nuclei](https://projectdiscovery.io/nuclei) by ProjectDiscovery, the open-source vulnerability scanner. It exposes
+ready-to-use, tag-based scan contracts (cloud, misconfiguration, exposure, CVE, panel, XSS, WordPress and full
+templates) plus per-CVE contracts kept in sync with the official Nuclei CVE catalog. It resolves the targets from your
+OpenAEV assets or from manual input, runs the scan, and reports the discovered CVEs and other findings back to OpenAEV
+as structured results.
+
 ## Table of Contents
 
 - [OpenAEV Nuclei Injector](#openaev-nuclei-injector)
-  - [Prerequisites](#prerequisites)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [How it works](#how-it-works)
+  - [Requirements](#requirements)
   - [Configuration variables](#configuration-variables)
     - [OpenAEV environment variables](#openaev-environment-variables)
     - [Base injector environment variables](#base-injector-environment-variables)
+    - [Nuclei injector environment variables](#nuclei-injector-environment-variables)
   - [Deployment](#deployment)
     - [Docker Deployment](#docker-deployment)
     - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+  - [Inject contracts](#inject-contracts)
+  - [Target selection](#target-selection)
   - [Behavior](#behavior)
-    - [Template Selection](#template-selection)
-    - [Target Selection](#target-selection)
-  - [Resources](#resources)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
 
----
+## Introduction
 
-## Prerequisites
+OpenAEV (Breach and Attack Simulation) drives injectors to execute the technical actions of a scenario. The Nuclei
+injector registers a set of scan contracts with the OpenAEV platform; when an inject using one of these contracts is
+played, OpenAEV dispatches a job to the injector, which runs the corresponding Nuclei scan and returns the results. In
+addition to the static contracts, the injector maintains a catalog of per-CVE contracts in the background so each
+published Nuclei CVE template can be played individually.
 
-This injector uses [ProjectDiscovery Nuclei](https://github.com/projectdiscovery/nuclei) to scan assets.
+## How it works
 
-Depending on your deployment method:
+Injectors receive their jobs through the message broker (RabbitMQ) configured by the OpenAEV platform. The injector
+fetches the broker connection details from OpenAEV at startup, so it only needs to be able to reach the OpenAEV URL and
+the RabbitMQ host/port advertised by the platform.
 
-- When using the **Docker deployment**, **Nuclei is bundled** within the image.
-- When running manually (e.g., in development), **Nuclei must be installed locally** and available in the system's `PATH`.
+## Requirements
 
-In both cases, for the injector to operate correctly:
-
-- It **must be able to reach the OpenAEV platform** via the URL you provide (through `OPENAEV_URL` or `config.yml`).
-- It **must be able to reach the RabbitMQ broker** used by the OpenAEV platform.
-
----
+- A running OpenAEV platform, reachable from the injector (along with its RabbitMQ broker)
+- For a manual (non-Docker) deployment:
+  - Python >= 3.11 and [Poetry](https://python-poetry.org/) >= 2.1
+  - The `nuclei` binary available on the `PATH` (the Docker image bundles Nuclei `v3.8.0`)
+  - Outbound network access to `raw.githubusercontent.com` and `github.com` so the injector can update the Nuclei
+    templates and sync the per-CVE contracts
 
 ## Configuration variables
 
-Configuration is provided either through environment variables (Docker) or a config
-file (`config.yml`, manual).
+The injector is configured either through environment variables (recommended, read from `docker-compose.yml` / the
+`.env` file for a Docker deployment) or through a `config.yml` file (for a manual deployment). Copy the provided
+`.env.sample` / `config.yml.sample` and fill in the values flagged with `ChangeMe`.
 
 ### OpenAEV environment variables
 
-| Parameter          | config.yml | Docker environment variable | Mandatory | Description                                           |
-|--------------------|------------|-----------------------------|-----------|-------------------------------------------------------|
-| OpenAEV URL        | url        | `OPENAEV_URL`               | Yes       | The URL of the OpenAEV platform.                      |
-| OpenAEV Token      | token      | `OPENAEV_TOKEN`             | Yes       | The default admin token set in the OpenAEV platform.  |
-| OpenAEV Tenant ID  | tenant_id  | `OPENAEV_TENANT_ID`         | No        | Identifier of the tenant within the OpenAEV platform. |
-
-> ⚠️ Warning ⚠️
->
-> The `tenant_id` parameter is a new configuration option. A period of backward compatibility is ensured: if this key is not defined,
-> existing configurations will not be affected, and the default value will be `None`. However, if a value is provided, it will be
-> validated by Pydantic and must conform to a valid UUID format, otherwise, a validation error will be returned.
+| Parameter         | config.yml          | Docker environment variable | Mandatory | Description                                                                        |
+|-------------------|---------------------|-----------------------------|-----------|------------------------------------------------------------------------------------|
+| OpenAEV URL       | `openaev.url`       | `OPENAEV_URL`               | Yes       | The URL of the OpenAEV platform. Must be reachable from where the injector runs.   |
+| OpenAEV Token     | `openaev.token`     | `OPENAEV_TOKEN`             | Yes       | The administrator token of the OpenAEV platform.                                   |
+| OpenAEV Tenant ID | `openaev.tenant_id` | `OPENAEV_TENANT_ID`         | No        | Tenant identifier for multi-tenant deployments. When set, it must be a valid UUID. |
 
 ### Base injector environment variables
 
-| Parameter                               | config.yml                                                 | Docker environment variable                                | Default | Mandatory | Description                                                                                         |
-|-----------------------------------------|------------------------------------------------------------|------------------------------------------------------------|---------|-----------|-----------------------------------------------------------------------------------------------------|
-| Injector ID                             | `injector.id`                                              | `INJECTOR_ID`                                              | /       | Yes       | A unique `UUIDv4` identifier for this injector instance.                                            |
-| Injector Name                           | `injector.name`                                            | `INJECTOR_NAME`                                            |         | Yes       | Name of the injector.                                                                               |
-| Log Level                               | `injector.log_level`                                       | `INJECTOR_LOG_LEVEL`                                       | info    | Yes       | Determines the verbosity of the logs. Options: `debug`, `info`, `warn`, or `error`.                 |
-| External contracts maintenance schedule | `injector.external_contracts_maintenance_schedule_seconds` | `INJECTOR_EXTERNAL_CONTRACTS_MAINTENANCE_SCHEDULE_SECONDS` | 86400   | No        | With every tick, trigger a maintenance of the external contracts (e.g. based on Nuclei templates)   |
+| Parameter     | config.yml           | Docker environment variable | Default | Mandatory | Description                                                     |
+|---------------|----------------------|-----------------------------|---------|-----------|-----------------------------------------------------------------|
+| Injector ID   | `injector.id`        | `INJECTOR_ID`               | /       | Yes       | A unique `UUIDv4` identifier for this injector instance.        |
+| Injector Name | `injector.name`      | `INJECTOR_NAME`             | Nuclei  | No        | The name of the injector as shown in OpenAEV.                   |
+| Log Level     | `injector.log_level` | `INJECTOR_LOG_LEVEL`        | error   | No        | Verbosity of the logs. One of `debug`, `info`, `warn`, `error`. |
 
----
+### Nuclei injector environment variables
 
-### Nuclei environment variables
+These tune how Nuclei runs. Each maps to a Nuclei command-line flag (shown in the description). `exclude_type` and
+`exclude_severity` accept comma-separated values.
 
-| Parameter                              | config.yml                              | Docker environment variable             | Default      | Mandatory | Description                                                                                          |
-|----------------------------------------|-----------------------------------------|-----------------------------------------|--------------|-----------|------------------------------------------------------------------------------------------------------|
-| Nuclei Scan Strategy                   | `nuclei.scan_strategy`                  | `NUCLEI_SCAN_STRATEGY`                  | `host-spray` | No        | Strategy to use while scanning (auto, host-spray, template-spray). Nuclei Flags: -ss, -scan-strategy |
-| Nuclei Templates Parallelism           | `nuclei.templates_parallelism`          | `NUCLEI_TEMPLATES_PARALLELISM`          | `5`          | No        | Maximum number of templates to be executed in parallel. Nuclei Flags: -c, -concurrency               |
-| Nuclei Hosts parallelism per templates | `nuclei.hosts_parallelism_per_template` | `NUCLEI_HOSTS_PARALLELISM_PER_TEMPLATE` | `5`          | No        | Maximum number of hosts to be analyzed in parallel per template. Nuclei Flags: -bs, -bulk-size       |
-| Nuclei Max requests per second         | `nuclei.max_requests_per_second`        | `NUCLEI_MAX_REQUESTS_PER_SECOND`        | `50`         | No        | Maximum number of requests to send per second. Nuclei Flags: -rl, -rate-limit                        |
-| Nuclei Timeout                         | `nuclei.timeout`                        | `NUCLEI_TIMEOUT`                        | `10`         | No        | Time to wait in seconds before timeout. Nuclei Flags: -timeout                                       |
-| Nuclei Retries                         | `nuclei.retries`                        | `NUCLEI_RETRIES`                        | `1`          | No        | Number of times to retry a failed request. Nuclei Flags: -retries                                    |
-| Nuclei Max host error                  | `nuclei.max_host_error`                 | `NUCLEI_MAX_HOST_ERROR`                 | `30`         | No        | Max errors for a host before skipping from scan. Nuclei Flags: -mhe, -max-host-error                 |
-| Nuclei response size read              | `nuclei.response_size_read`             | `NUCLEI_RESPONSE_SIZE_READ`             | `1048576`    | No        | Max response size to read in bytes. Nuclei Flags: -rsr, -response-size-read                          |
-| Nuclei response size save              | `nuclei.response_size_save`             | `NUCLEI_RESPONSE_SIZE_SAVE`             | `1048576`    | No        | Max response size to save in bytes. Nuclei Flags: -rss, -response-size-save                          |
-| Nuclei exclude type                    | `nuclei.exclude_type`                   | `NUCLEI_EXCLUDE_TYPE`                   | `headless`   | No        | Templates to exclude based on protocol type (comma-separated). Nuclei Flags: -ept, -exclude-type     |
-| Nuclei exclude severity                | `nuclei.exclude_severity`               | `NUCLEI_EXCLUDE_SEVERITY`               | /            | No        | Templates to exclude based on severity (comma-separated). Nuclei Flags: -es, -exclude-severity       |
-
-#### Nuclei Resource Management
-
-> [!IMPORTANT]
-> 
-> To ensure optimal stability, security, and compatibility, Nuclei must be kept up to date. 
-> Recommended Nuclei version: v3.8.0
-
-Nuclei is a highly concurrent vulnerability scanner. While this enables fast and scalable scans, it can also lead to 
-significant CPU, memory, and network consumption if not properly configured. For this reason, Nuclei injector exposes a 
-controlled subset of Nuclei performance and safety parameters that can be adjusted based on infrastructure capacity and 
-scanning requirements.
-
-The default injector configuration is intentionally conservative and designed as a safe baseline for containerized 
-environments, including Kubernetes clusters with typical memory limits of `256Mi`-`512Mi` per pod.
-
-> [!WARNING]
-> 
-> If flags and available options are not properly configured, Nuclei can overutilize resources and can cause the 
-> following issues:
-> - OOM Killed by the system
-> - Hangs and crashes
-> - Error code 137 etc
-
-Resource consumption scales multiplicatively rather than linearly, meaning that increasing multiple parameters 
-simultaneously significantly amplifies memory and CPU usage.
-
-| Parameter                        | Corresponding Flag   | Safe  | Balanced | Fast    |
-|----------------------------------|----------------------|-------|----------|---------|
-| `templates_parallelism`          | `-c`, `-concurrency` | 5–10  | 10–15    | 15–25   |
-| `hosts_parallelism_per_template` | `-bs`, `-bulk-size`  | 5–10  | 10–15    | 15–25   |
-| `max_requests_per_second`        | `-rl`, `-rate-limit` | 20–50 | 50–100   | 100–150 |
-
-These parameters are interdependent and must be adjusted together rather than in isolation. They should also be 
-adjusted gradually according to the infrastructure capacity and workload characteristics.
-
-Configuration tuning should always take into account the execution context:
-- For `single-target` scans, higher concurrency values can be safely used to improve performance.
-- For `multi-target` scans, it is recommended to use more conservative settings to avoid resource saturation.
-
-Nuclei configuration requires careful trade-offs, as these parameters directly impact performance, stability, and 
-resource consumption.
-
-The following guidelines should be considered:
-- Higher safety settings increase scan duration but improve stability.
-- `host-spray` is the recommended scan strategy for predictable and stable resource usage.
-- `max_host_error` must be greater than `templates_parallelism` and `hosts_parallelism_per_template` to prevent 
-premature host exclusion under high concurrency workloads.
-- `headless` templates should be used with caution due to their high resource consumption (embedded headless browser 
-execution).
-- Increasing template exclusions (`exclude_type`, `exclude_severity`) reduces the active template set and improves scan 
-performance.
-
-> [!WARNING]
-> 
-> The `response_size_read` parameter has a direct impact on memory consumption:
-> Memory usage is approximately proportional to:
-> - 1–1.5 × (`templates_parallelism` × `response_size_read`)
-> 
-> For this reason, increasing both `templates_parallelism` and `response_size_read` simultaneously can significantly 
-> increase memory pressure and lead to `OOM Killed` in constrained environments.
-
-For more information:
-- See [Nuclei's documentation on mass scanning](https://docs.projectdiscovery.io/opensource/nuclei/mass-scanning-cli#understanding-how-nuclei-consumes-resources)
-- See [Nuclei's documentation on flags](https://docs.projectdiscovery.io/opensource/nuclei/running#nuclei-flags)
+| Parameter                      | config.yml                              | Docker environment variable             | Default   | Mandatory | Description                                                                                                    |
+|--------------------------------|-----------------------------------------|-----------------------------------------|-----------|-----------|----------------------------------------------------------------------------------------------------------------|
+| Scan strategy                  | `nuclei.scan_strategy`                  | `NUCLEI_SCAN_STRATEGY`                  | host-spray| No        | Strategy used while scanning. One of `auto`, `host-spray`, `template-spray` (`-scan-strategy`).                |
+| Templates parallelism          | `nuclei.templates_parallelism`          | `NUCLEI_TEMPLATES_PARALLELISM`          | 5         | No        | Maximum number of templates executed in parallel (`-concurrency`).                                             |
+| Hosts parallelism per template | `nuclei.hosts_parallelism_per_template` | `NUCLEI_HOSTS_PARALLELISM_PER_TEMPLATE` | 5         | No        | Maximum number of hosts analyzed in parallel per template (`-bulk-size`).                                      |
+| Max requests per second        | `nuclei.max_requests_per_second`        | `NUCLEI_MAX_REQUESTS_PER_SECOND`        | 50        | No        | Maximum number of requests sent per second (`-rate-limit`).                                                    |
+| Timeout                        | `nuclei.timeout`                        | `NUCLEI_TIMEOUT`                        | 10        | No        | Time to wait in seconds before timeout (`-timeout`).                                                           |
+| Retries                        | `nuclei.retries`                        | `NUCLEI_RETRIES`                        | 1         | No        | Number of times to retry a failed request (`-retries`).                                                        |
+| Max host error                 | `nuclei.max_host_error`                 | `NUCLEI_MAX_HOST_ERROR`                 | 30        | No        | Max errors for a host before skipping it from the scan (`-max-host-error`).                                    |
+| Response size read             | `nuclei.response_size_read`             | `NUCLEI_RESPONSE_SIZE_READ`             | 1048576   | No        | Max response size to read, in bytes (`-response-size-read`).                                                   |
+| Response size save             | `nuclei.response_size_save`             | `NUCLEI_RESPONSE_SIZE_SAVE`             | 1048576   | No        | Max response size to save, in bytes (`-response-size-save`).                                                   |
+| Exclude type                   | `nuclei.exclude_type`                   | `NUCLEI_EXCLUDE_TYPE`                   | headless  | No        | Protocol types to exclude: `dns`, `file`, `http`, `headless`, `tcp`, `workflow`, `ssl`, `websocket`, `whois`, `code`, `javascript` (`-exclude-type`). |
+| Exclude severity               | `nuclei.exclude_severity`               | `NUCLEI_EXCLUDE_SEVERITY`               | /         | No        | Severities to exclude: `info`, `low`, `medium`, `high`, `critical`, `unknown` (`-exclude-severity`).           |
 
 ## Deployment
 
 ### Docker Deployment
 
-Build the Docker image using the provided `Dockerfile`.
+This injector depends on the shared `injector_common` package, so the image must be built with a build context that
+exposes it:
 
-```bash
-docker build --build-context injector_common=../injector_common .  -t openaev/injector-nuclei:latest
-````
+```shell
+docker build --build-context injector_common=../injector_common . -t openaev/injector-nuclei:latest
+```
 
-Edit the `docker-compose.yml` file with your OpenAEV configuration, then start the container:
+Create a `.env` file from `.env.sample` and fill in your values, then start the injector with the provided
+`docker-compose.yml`:
 
-```bash
+```shell
 docker compose up -d
 ```
 
-> ✅ The Docker image **already contains Nuclei**. No further installation is needed inside the container.
-
----
-
-#### Domain name resolution - Local openAEV with Injector container
-**Note:** If you are running OpenAEV locally on your host machine and want to run this injector inside a Docker container, the `openaev` URL defined in `config.yml` and `.env` must be reachable from inside the container.
-
-Inside a container, `localhost` refers to the container itself - not your host machine. Therefore, you cannot use `localhost` as the OpenAEV URL unless OpenAEV is running inside the same container.
-
-Instead, use: `host.docker.internal`. This hostname allows the container to access services running on your host machine.
-
-**In short**:
-- `localhost` -> container itself
-- `host.docker.internal` -> your host machine
-
-**Platform-specific notes**:
-- **macOS / Windows (Docker Desktop):**     
-  `host.docker.internal` works out of the box. No additional configuration is needed.
-- **Linux:**  
-  You must explicitly map it using `extra_hosts`:
-```yaml
-services:
-  your-injector-name:
-    image: your-image-name
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-```
-
-**Important**:
-- Avoid mapping `host.docker.internal` to a fixed IP (e.g. `1.2.3.4`) unless you have a specific reason. The host IP can change, and Docker provides `host-gateway` to handle this dynamically.
-- Make sure your OpenAEV service is listening on `0.0.0.0` (not just `localhost`), otherwise it may NOT be accessible from the container.
-
----
+> If OpenAEV runs on your host machine while the injector runs in a container, set `OPENAEV_URL` to
+> `http://host.docker.internal:<port>` rather than `localhost`. On Linux, also add
+> `extra_hosts: ["host.docker.internal:host-gateway"]` to the service, and make sure OpenAEV listens on `0.0.0.0`.
 
 ### Manual Deployment
 
-#### Prerequisites
-
-* **Nuclei must be installed locally** and accessible via the command line (`nuclei` command).
-* You can install it from: [https://github.com/projectdiscovery/nuclei#installation](https://github.com/projectdiscovery/nuclei#installation)
-
-The poetry package management system (version 2.1 or later) must also be available: https://python-poetry.org/
-Install the environment:
-
-**Production**:
-```shell
-# production environment
-poetry install 
-```
-
-**Development** (note that you should also clone the [pyoaev](OpenAEV-Platform/client-python) repository [according to
-these instructions](../README.md#simultaneous-development-on-pyoaev-and-an-injector))
-```shell
-# development environment
-poetry install --extras dev
-```
-
-Then, start the collector:
+Make sure the `nuclei` binary is installed and on your `PATH` (the Docker image bundles `v3.8.0`), create a `config.yml`
+from `config.yml.sample`, then install and run the injector:
 
 ```shell
+poetry install
 poetry run python -m nuclei.openaev_nuclei
 ```
 
----
+> For local development against a checkout of [client-python](https://github.com/OpenAEV-Platform/client-python)
+> (cloned next to this repository), use `poetry install --extras dev`.
+
+## Usage
+
+Once started, the injector registers its contracts with OpenAEV and waits for jobs. Add a Nuclei inject to a scenario or
+atomic testing, select the scan type and the targets, and play it: the results are attached to the inject once the scan
+completes. The injector also checks that the `nuclei` binary is available at startup and refuses to start if it is not.
+
+## Inject contracts
+
+Each contract runs `nuclei` against the resolved targets (fed on standard input) and writes JSONL output (`-jsonl`).
+The static contracts select Nuclei templates by tag:
+
+| Contract                    | Templates selected             | Nuclei flag              |
+|-----------------------------|--------------------------------|--------------------------|
+| Nuclei - Cloud Templates    | Cloud templates                | `-tags cloud`            |
+| Nuclei - Misconfigurations  | Misconfiguration templates     | `-tags misconfiguration` |
+| Nuclei - Exposures          | Exposure templates             | `-tags exposure`         |
+| Nuclei - CVE Scan           | CVE templates                  | `-tags cve`              |
+| Nuclei - Panel Scan         | Login/admin panel templates    | `-tags panel`            |
+| Nuclei - XSS Scan           | Cross-site scripting templates | `-tags xss`              |
+| Nuclei - Wordpress Scan     | WordPress templates            | `-tags wordpress`        |
+| Nuclei - TEMPLATES Scan     | Full template set              | `-templates /`           |
+
+> The `Nuclei - TEMPLATES Scan` contract runs the broadest, slowest scan: when no manual template is set it invokes
+> `nuclei -templates /` to run Nuclei's full template set instead of a tag-filtered subset. Here `/` is the template
+> path passed to Nuclei (not a special "all templates" keyword); scope the scan down with the manual template path
+> field below whenever possible.
+
+Every contract also exposes two optional free-text fields:
+
+- `Manual template path (-t)` (`template`): run a specific template or template directory (`-templates <path>`).
+- `Options` (`options`): extra raw Nuclei flags, appended to the command line.
+
+In addition to the static contracts, a background scheduler maintains one contract per CVE. On each tick (every
+`86400` seconds / 24h by default) it runs `nuclei -update-templates`, fetches the official Nuclei CVE catalog
+(`cves.json` from the `projectdiscovery/nuclei-templates` repository), and creates, updates or deletes the matching
+per-CVE contracts. Each per-CVE contract is labelled with the CVE/template ID and pre-fills the template path of that
+CVE.
+
+Common inject fields and outputs:
+
+- Inputs: target selector (`Assets`, `Asset groups` (default), `Manual`), targeted assets / asset groups, the targeted
+  asset property, manual targets (comma-separated) and expectations (predefined `Not vulnerable`, score 100).
+- Outputs: `cve` (CVE findings, finding-compatible) and `others` (other text findings). The execution message
+  summarizes how many CVEs and other vulnerabilities were found, or `Good News: Nothing Found !`.
+
+## Target selection
+
+Targets are resolved through the shared selection logic of `injector_common`:
+
+- Target selector: `assets`, `asset-groups` (default), or `manual`.
+- Target property selector (for assets / asset groups): `automatic` (default), `seen_ip`, `local_ip` (first), or
+  `hostname`.
+
+| Target property   | Asset field used                                   |
+|-------------------|----------------------------------------------------|
+| Automatic         | Hostname for agentless assets, else first valid IP |
+| Seen IP           | `endpoint_seen_ip`                                 |
+| Local IP (first)  | First valid entry in `endpoint_ips`                |
+| Hostname          | `endpoint_hostname`                                |
+
+For manual targets, provide hostnames or IP addresses as comma-separated values. Invalid, loopback, unspecified and
+link-local addresses are filtered out.
 
 ## Behavior
 
-The Nuclei injector supports contract-based scans by dynamically constructing and executing Nuclei
-commands based on provided tags or templates.
-
-### Supported Contracts
-
-The following scan types are supported via `-tags`:
-
-- Cloud
-- Misconfiguration
-- Exposure
-- Panel
-- XSS
-- WordPress
-- HTTP
-
-The CVE scan uses the `-tags cve` argument and enforces JSON output.
-
-The Template scan accepts a manual template via `-t <template>` or `template_path`.
-
-Additionally, contracts dedicated to scanning for a single, specific CVE may be provisioned in OpenAEV if
-two conditions are met:
-
-* A scan for the CVE is supported by a Nuclei template (part of the Nuclei distribution),
-* A vulnerability taxonomy entry exists in OpenAEV for that same CVE (under Settings > Taxonomies > Vulnerabilities).
-
-These CVE-specific contracts are set up out of the box to use the Nuclei template (with the `-t` argument)
-relevant to the CVE.
-
-### Target Selection
-
-Targets are selected based on the `target_selector` field.
-
-#### If target type is **Assets**:
-
-| Selected Property | Uses Asset Field           |
-|-------------------|----------------------------|
-| Seen IP           | endpoint_seen_ip           |
-| Local IP          | First IP from endpoint_ips |
-| Hostname          | endpoint_hostname          |
-
-#### If target type is **Manual**:
-
-Direct comma-separated values of IPs or hostnames are used.
-
-### Options
-
-You can add any options you want based on what is available for nuclei
-
-### Example Execution
-
-A sample command executed by this injector might look like:
-
-```bash
-nuclei -u 192.168.1.10 -tags xss
-```
-Or with a specific template:
-```bash
-nuclei -u 10.0.0.5 -t cves/2021/CVE-2021-1234.yaml -j
-```
-Or with options:
-```bash
-nuclei -u https://www.google.com -t dast/vulnerabilities/sqli/sqli-error-based.yaml -dast
+```mermaid
+flowchart LR
+    O[OpenAEV inject] -->|job via RabbitMQ| I(Nuclei injector)
+    I -->|resolve targets| T[Assets / Asset groups / Manual]
+    I -->|nuclei -tags/-templates -jsonl| N[Nuclei]
+    N -->|JSONL| P[Output parser]
+    P -->|CVE + others| I
+    I -->|structured results| O
 ```
 
-### Output Parsing
-- The injector captures and parses the JSON output of Nuclei, and returns:
+On each job the injector acknowledges reception, resolves the targets, builds the `nuclei` command line from the
+contract tag and the configured options, runs the scan with the targets on standard input, parses the JSONL output into
+CVE findings and other results, and returns a structured result (linked to the scanned asset when applicable) together
+with a success or error status. A separate background scheduler keeps the per-CVE contracts in sync with the Nuclei CVE
+catalog.
 
-- Confirmed findings (if any) with severity and CVE IDs
+## Debugging
 
-- Other lines as unstructured output
+Set `INJECTOR_LOG_LEVEL=debug` to log the resolved targets and the exact `nuclei` command line that is executed (logged
+as `Executing nuclei with: ...`). For manual deployments, the most common issue is a missing `nuclei` binary on the
+`PATH` (the injector checks `nuclei -version` at startup). If the per-CVE contracts are not appearing or updating, check
+that the injector can reach `raw.githubusercontent.com` and review the maintenance logs.
 
-### Results
+## Additional information
 
-Scan results are categorized into:
-
-- **CVEs** (based on template classifications)
-- **Other vulnerabilities** (general issues found)
-
-If no vulnerabilities are detected, the injector will clearly indicate this with a **"Nothing Found"** message.
-
----
-
-## Resources
-
-* [Nuclei Documentation](https://github.com/projectdiscovery/nuclei)
-* [Official Nuclei Templates](https://github.com/projectdiscovery/nuclei-templates)
-* http://testphp.vulnweb.com/ is a safe, intentionally vulnerable target provided by Acunetix for security testing purposes
+- Official Nuclei documentation: [https://docs.projectdiscovery.io/tools/nuclei/overview](https://docs.projectdiscovery.io/tools/nuclei/overview)
+- Nuclei flags reference: [https://docs.projectdiscovery.io/tools/nuclei/running](https://docs.projectdiscovery.io/tools/nuclei/running)
+- Nuclei templates and CVE catalog: [https://github.com/projectdiscovery/nuclei-templates](https://github.com/projectdiscovery/nuclei-templates)

--- a/shodan/README.md
+++ b/shodan/README.md
@@ -1,435 +1,217 @@
 # OpenAEV Shodan Injector
 
+The Shodan injector lets OpenAEV run OSINT discovery actions as part of attack scenarios using the
+[Shodan](https://www.shodan.io/) REST API. It exposes ready-to-use inject contracts (cloud asset discovery, critical
+ports / exposed admin interfaces, CVE enumeration and watchlists, domain and IP discovery, and a free-form custom query),
+resolves the targets from your OpenAEV assets or from manual input, queries Shodan, and reports the matches back to
+OpenAEV - optionally creating assets from the results.
+
 ## Table of Contents
 
-- [OpenAEV SHODAN Injector](#openaev-shodan-injector)
-    - [Prerequisites](#prerequisites)
-    - [Configuration variables](#configuration-variables)
-        - [Base OpenAEV environment variables](#base-openaev-environment-variables)
-        - [Base injector environment variables](#base-injector-environment-variables)
-        - [Base Shodan environment variables](#base-shodan-environment-variables)
-    - [Deployment](#deployment)
-        - [Docker Deployment](#docker-deployment)
-        - [Manual Deployment](#manual-deployment)
-    - [Behavior](#behavior)
-    - [Supported Contracts](#supported-contracts)
-        - [Fields available in manual mode by contract](#fields-available-in-manual-mode-by-contract)
-        - [Output Trace Message](#output-trace-message)
-        - [Auto-Create Assets](#auto-create-assets)
-        - [Rate Limiting and Retry](#rate-limiting-and-retry)
-    - [Resources](#resources)
+- [OpenAEV Shodan Injector](#openaev-shodan-injector)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [How it works](#how-it-works)
+  - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenAEV environment variables](#openaev-environment-variables)
+    - [Base injector environment variables](#base-injector-environment-variables)
+    - [Shodan injector environment variables](#shodan-injector-environment-variables)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+  - [Inject contracts](#inject-contracts)
+  - [Target selection](#target-selection)
+  - [Behavior](#behavior)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
 
----
+## Introduction
 
-## Prerequisites
+OpenAEV (Breach and Attack Simulation) drives injectors to execute the technical actions of a scenario. The Shodan
+injector registers a set of discovery contracts with the OpenAEV platform; when an inject using one of these contracts is
+played, OpenAEV dispatches a job to the injector, which builds the matching Shodan query, calls the Shodan REST API and
+returns the results.
 
-This injector uses [Shodan](https://www.shodan.io/) to collect information about exposed assets.
+## How it works
 
-To operate correctly, the injector requires:
+Injectors receive their jobs through the message broker (RabbitMQ) configured by the OpenAEV platform. The injector
+fetches the broker connection details from OpenAEV at startup, so it only needs to be able to reach the OpenAEV URL and
+the RabbitMQ host/port advertised by the platform. At execution time, it also needs outbound access to the Shodan API.
 
-- A **valid Shodan API key**, which must be provided through an environment variable (`SHODAN_API_KEY`) or via the `config.yml` file.
-- You can create an account on this page: https://account.shodan.io/register
+## Requirements
 
-In addition, for proper integration with the OpenAEV platform:
-
-- It **must be able to reach the OpenAEV platform** via the URL you provide (through `OPENAEV_URL` or `config.yml`).
-- It **must be able to reach the RabbitMQ broker** used by the OpenAEV platform.
-
-Depending on your deployment method:
-
-- When using the **Docker deployment**, ensure the Shodan API key is correctly injected into the container environment.
-- When running manually (e.g., in development), the Shodan API key must be available in your local environment.
-
----
+- A running OpenAEV platform, reachable from the injector (along with its RabbitMQ broker).
+- A valid Shodan API key (`SHODAN_API_KEY`) and outbound network access to `https://api.shodan.io`.
+- No additional system binaries are required: the Shodan API is called with the Python `requests` library.
+- The Docker image must be built with `--build-context injector_common=../injector_common`, because the injector depends
+  on the shared `injector_common` package located one level above this directory.
+- For a manual (non-Docker) deployment:
+  - Python >= 3.11 and [Poetry](https://python-poetry.org/) >= 2.1.
 
 ## Configuration variables
 
-Configuration is provided either through environment variables (Docker) or a config
-file (`config.yml`, manual).
+The injector is configured either through environment variables (recommended, read from `docker-compose.yml` / the
+`.env` file for a Docker deployment) or through a `config.yml` file (for a manual deployment). Copy the provided
+`.env.sample` / `config.yml.sample` and fill in the values flagged with `ChangeMe`.
 
----
+### OpenAEV environment variables
 
-### Base OpenAEV environment variables
-
-| Parameter         | config.yml | Docker environment variable | Mandatory | Description                                           |
-|-------------------|------------|-----------------------------|-----------|-------------------------------------------------------|
-| OpenAEV URL       | url        | `OPENAEV_URL`               | Yes       | The URL of the OpenAEV platform.                      |
-| OpenAEV Token     | token      | `OPENAEV_TOKEN`             | Yes       | The default admin token set in the OpenAEV platform.  |
-| OpenAEV Tenant ID | tenant_id  | `OPENAEV_TENANT_ID`         | No        | Identifier of the tenant within the OpenAEV platform. |
-
-> ⚠️ Warning ⚠️
-> 
-> The `tenant_id` parameter is a new configuration option. A period of backward compatibility is ensured: if this key is not defined, 
-> existing configurations will not be affected, and the default value will be `None`. However, if a value is provided, it will be
-> validated by Pydantic and must conform to a valid UUID format, otherwise, a validation error will be returned.
-
+| Parameter         | config.yml          | Docker environment variable | Mandatory | Description                                                                        |
+|-------------------|---------------------|-----------------------------|-----------|------------------------------------------------------------------------------------|
+| OpenAEV URL       | `openaev.url`       | `OPENAEV_URL`               | Yes       | The URL of the OpenAEV platform. Must be reachable from where the injector runs.   |
+| OpenAEV Token     | `openaev.token`     | `OPENAEV_TOKEN`             | Yes       | The administrator token of the OpenAEV platform.                                   |
+| OpenAEV Tenant ID | `openaev.tenant_id` | `OPENAEV_TENANT_ID`         | No        | Tenant identifier for multi-tenant deployments. When set, it must be a valid UUID. |
 
 ### Base injector environment variables
 
-| Parameter     | config.yml | Docker environment variable  | Default          | Mandatory | Description                                                                            |
-|---------------|------------|------------------------------|------------------|-----------|----------------------------------------------------------------------------------------|
-| Injector ID   | id         | `INJECTOR_ID`                | `shodan--<uuid>` | No        | A unique `UUIDv4` identifier for this injector instance.                               |
-| Injector Name | name       | `INJECTOR_NAME`              | `Shodan`         | No        | Name of the injector.                                                                  |
-| Log Level     | log_level  | `INJECTOR_LOG_LEVEL`         | `error`          | No        | Determines the verbosity of the logs. Options: `debug`, `info`, `warning`, or `error`. |
+| Parameter     | config.yml           | Docker environment variable | Default | Mandatory | Description                                                     |
+|---------------|----------------------|-----------------------------|---------|-----------|-----------------------------------------------------------------|
+| Injector ID   | `injector.id`        | `INJECTOR_ID`               | /       | Yes       | A unique `UUIDv4` identifier for this injector instance.        |
+| Injector Name | `injector.name`      | `INJECTOR_NAME`             | Shodan  | No        | The name of the injector as shown in OpenAEV.                   |
+| Log Level     | `injector.log_level` | `INJECTOR_LOG_LEVEL`        | error   | No        | Verbosity of the logs. One of `debug`, `info`, `warn`, `error`. |
 
+### Shodan injector environment variables
 
-### Base Shodan environment variables
-
-| Parameter                        | config.yml                | Docker environment variable        | Default                 | Mandatory | Description                                                                                                                                                                                    |
-|----------------------------------|---------------------------|------------------------------------|-------------------------|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Shodan Base URL                  | token                     | `SHODAN_BASE_URL`                  | `https://api.shodan.io` | No        | This is the base URL for the Shodan API.                                                                                                                                                       |
-| Shodan API Key                   | api_key                   | `SHODAN_API_KEY`                   | /                       | Yes       | This is the API key for the Shodan API.                                                                                                                                                        |
-| Shodan API leaky bucket rate     | api_leaky_bucket_rate     | `SHODAN_API_LEAKY_BUCKET_RATE`     | `10`                    | No        | Bucket refill rate (in tokens per second). Controls the rate at which API calls are allowed. For example, a rate of 10 means that 10 calls can be made per second, if the bucket is not empty. |
-| Shodan API leaky bucket capacity | api_leaky_bucket_capacity | `SHODAN_API_LEAKY_BUCKET_CAPACITY` | `10`                    | No        | Maximum bucket capacity (in tokens). Defines the number of calls that can be made immediately in a burst. Once the bucket is empty, it refills at the rate defined by 'api_leaky_bucket_rate'. |
-| Shodan API Retry                 | api_retry                 | `SHODAN_API_RETRY`                 | `5`                     | No        | Maximum number of attempts (including the initial request) in case of API failure.                                                                                                             |
-| Shodan API backoff               | api_backoff               | `SHODAN_API_BACKOFF`               | `PT30S`                 | No        | Maximum exponential backoff delay between retry attempts (ISO 8601 duration format).                                                                                                           |
-
----
+| Parameter                        | config.yml                       | Docker environment variable        | Default                 | Mandatory | Description                                                                                          |
+|----------------------------------|----------------------------------|------------------------------------|-------------------------|-----------|------------------------------------------------------------------------------------------------------|
+| Shodan API Key                   | `shodan.api_key`                 | `SHODAN_API_KEY`                   | /                       | Yes       | API key used to authenticate against the Shodan REST API.                                            |
+| Shodan Base URL                  | `shodan.base_url`                | `SHODAN_BASE_URL`                  | `https://api.shodan.io` | No        | Base URL of the Shodan API.                                                                          |
+| API leaky bucket rate            | `shodan.api_leaky_bucket_rate`   | `SHODAN_API_LEAKY_BUCKET_RATE`     | `10`                    | No        | Bucket refill rate (tokens per second): how many calls are allowed per second when the bucket is not empty. |
+| API leaky bucket capacity        | `shodan.api_leaky_bucket_capacity` | `SHODAN_API_LEAKY_BUCKET_CAPACITY` | `10`                  | No        | Maximum bucket capacity (tokens): the burst size allowed before requests are paced.                  |
+| API retry                        | `shodan.api_retry`               | `SHODAN_API_RETRY`                 | `5`                     | No        | Maximum number of attempts (including the initial request) on API failure.                           |
+| API backoff                      | `shodan.api_backoff`             | `SHODAN_API_BACKOFF`               | `PT30S`                 | No        | Maximum exponential backoff delay between retries (ISO 8601 duration, e.g. `PT30S`).                 |
 
 ## Deployment
 
----
-
 ### Docker Deployment
 
-Build the Docker image using the provided `Dockerfile`:
+This injector depends on the shared `injector_common` package, so the image must be built with a build context that
+exposes it:
 
-```bash
+```shell
 docker build --build-context injector_common=../injector_common . -t openaev/injector-shodan:latest
 ```
 
-Edit the `docker-compose.yml` file with your OpenAEV configuration, then start the container:
+Create a `.env` file from `.env.sample` and fill in your values (including `SHODAN_API_KEY`), then start the injector
+with the provided `docker-compose.yml`:
 
-```bash
+```shell
 docker compose up -d
 ```
 
-> ✅ The Docker image already includes the Shodan injector and its runtime dependencies.  
-Only a valid `SHODAN_API_KEY` and access to the OpenAEV platform are required at runtime.
-
----
-
-#### Domain name resolution - Local openAEV with Injector container
-**Note:** If you are running OpenAEV locally on your host machine and want to run this injector inside a Docker container, the `openaev` URL defined in `config.yml` and `.env` must be reachable from inside the container.
-
-Inside a container, `localhost` refers to the container itself - not your host machine. Therefore, you cannot use `localhost` as the OpenAEV URL unless OpenAEV is running inside the same container.
-
-Instead, use: `host.docker.internal`. This hostname allows the container to access services running on your host machine.
-
-**In short**:
-- `localhost` -> container itself
-- `host.docker.internal` -> your host machine
-
-**Platform-specific notes**:
-- **macOS / Windows (Docker Desktop):**     
-  `host.docker.internal` works out of the box. No additional configuration is needed.
-- **Linux:**  
-  You must explicitly map it using `extra_hosts`:
-```yaml
-services:
-  your-injector-name:
-    image: your-image-name
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-```
-
-**Important**:
-- Avoid mapping `host.docker.internal` to a fixed IP (e.g. `1.2.3.4`) unless you have a specific reason. The host IP can change, and Docker provides `host-gateway` to handle this dynamically.
-- Make sure your OpenAEV service is listening on `0.0.0.0` (not just `localhost`), otherwise it may NOT be accessible from the container.
-
----
+> If OpenAEV runs on your host machine while the injector runs in a container, set `OPENAEV_URL` to
+> `http://host.docker.internal:<port>` rather than `localhost`. On Linux, also add
+> `extra_hosts: ["host.docker.internal:host-gateway"]` to the service, and make sure OpenAEV listens on `0.0.0.0`.
 
 ### Manual Deployment
 
-This injector can be run manually in different modes, depending on whether you want **production**, **current**, or **development/testing**.
+Create a `config.yml` from `config.yml.sample` (set at least `shodan.api_key`), then install and run the injector:
 
----
-
-#### Prerequisites
-
-- Python 3.11+ installed
-- Poetry installed (https://python-poetry.org/) / uv / pip
-- A valid `SHODAN_API_KEY` set as environment variable or in `config.yml`
-- Access to the OpenAEV platform (`OPENAEV_URL` / `OPENAEV_TOKEN`) and RabbitMQ
-
-
-#### Install and Run with Pip
-
-Use pip if you prefer a classic Python workflow or for **development/testing with local dependencies**.
-
-```bash
-# Create a virtual environment
-python -m venv .venv
-
-# Activate the venv 
-# Linux / macOS
-source .venv/bin/activate
-# Windows - Git Bash
-source .venv/Scripts/activate
-
-# Install prod dependencies (stable Pyoaev release)
-pip install .[prod]
-
-# Install current release from Git / latest
-pip install .[current]
-
-# Install dependencies (Dev + Test includes local client-python)
-pip install -r requirements.txt
+```shell
+poetry install
+poetry run python -m shodan
 ```
 
-Run the injector:
-The injector can be started using either the Python module or the console entry point, depending on how it was installed.
+> For local development against a checkout of [client-python](https://github.com/OpenAEV-Platform/client-python)
+> (cloned next to this repository), use `poetry install --extras dev`.
 
-Run as a Python module (recommended for Docker and simple setups)
-```bash
-python -m shodan
-```
+## Usage
 
-Run using the console entry point
-```bash
-# Requires the package to be installed and the virtual environment to be active
-ShodanInjector
-```
+Once started, the injector registers its contracts with OpenAEV and waits for jobs. Add a Shodan inject to a scenario or
+atomic testing, choose the contract, set the targets (assets, asset groups, or manual input) and any contract-specific
+fields, optionally enable "Auto-Create assets", then play it. The injector runs one Shodan search per resolved target,
+then makes a final call to retrieve your account quota/plan, and attaches a formatted report to the inject.
 
-**Why use pip:**
+Every contract exposes a target selector, an optional "Auto-Create assets" checkbox and expectations. In manual mode you
+fill the contract's own input fields:
 
-- Manages local modifiable dependencies (`../../client-python`) that Poetry cannot resolve automatically while complying with PEP.
-- Handles extras and entry points (ShodanInjector) defined in `pyproject.toml`
-- Installs development/test extras (`.[dev,test]`) in a Poetry-compatible venv.
+| Contract                                    | Manual-mode fields (mandatory in bold)            | Notable defaults                                                                 |
+|---------------------------------------------|---------------------------------------------------|----------------------------------------------------------------------------------|
+| Cloud Provider Asset Discovery              | **Cloud Provider**, **Hostname**, Organization    | Cloud Provider default `Google, Microsoft, Amazon, Azure`                        |
+| Critical Ports and Exposed Admin Interface  | **Port**, **Hostname**, Organization              | Port default `20,21,22,23,25,53,80,110,111,135,139,143,443,445,993,995,1723,3306,3389,5900,8080` |
+| CVE Enumeration                             | **Hostname**, Organization                        | -                                                                                |
+| CVE Specific Watchlist                      | **Vulnerability**, **Hostname**, Organization     | -                                                                                |
+| Domain Discovery                            | **Hostname**, Organization                        | -                                                                                |
+| IP Enumeration                              | **IP**                                            | -                                                                                |
+| Custom Query                                | **Custom Query**                                  | Manual targets only                                                              |
 
-#### Install and Run with Poetry
-Use Poetry for production or current releases, or to manage dependencies automatically in an isolated virtual environment.
+When the Organization field is left empty, the organization is derived from each hostname; otherwise the value is applied
+to all hostnames.
 
-```bash
-# Install prod dependencies (stable Pyoaev release)
-poetry install --extras prod
+## Inject contracts
 
-# Install current release from Git / latest
-poetry install --extras current
+All contracts share the label "Shodan" and produce a `found_assets` output (populated only when "Auto-Create assets" is
+enabled). Each contract issues `GET shodan/host/search` requests; the "Custom Query" contract sends your raw query
+string, while the others build a Shodan filter expression from the contract fields.
 
-# Tips For development/testing with local Pyoaev (client-python)
-poetry run pip install -r requirements.txt
-```
+| Contract                                    | Shodan query built                                            | Target mode               |
+|---------------------------------------------|---------------------------------------------------------------|---------------------------|
+| Shodan - Cloud Provider Asset Discovery     | `cloud.provider:<providers>` + `hostname` / `org`             | assets / asset-groups / manual |
+| Shodan - Critical ports and exposed admin interface | `port:<ports>` + `hostname` / `org`                   | assets / asset-groups / manual |
+| Shodan - CVE Enumeration                    | `has_vuln:true` + `hostname` / `org`                          | assets / asset-groups / manual |
+| Shodan - CVE specific watchlist             | `vuln:<cve>` + `hostname` / `org`                             | assets / asset-groups / manual |
+| Shodan - Domain discovery                   | `hostname:<host>,*.<host>` + `org`                            | assets / asset-groups / manual |
+| Shodan - IP Enumeration                     | `ip:<address>`                                                | assets / asset-groups / manual |
+| Shodan - Custom query                       | Raw `query=<your query>` passed straight to the search API    | manual only               |
 
-Run the injector:
-```bash
-poetry run ShodanInjector
-```
+For hostname-based contracts, each hostname is queried together with its wildcard (e.g. `hostname:filigran.io,*.filigran.io`).
 
-Run using the console entry point
-```bash
-# Requires the package to be installed and the virtual environment to be active
-ShodanInjector
-```
+## Target selection
 
-**Why use Poetry:**
+Targets can come from OpenAEV assets or from manual input, selected per inject:
 
-- Automatically creates and manages a virtual environment
-- Handles extras and entry points (ShodanInjector) defined in `pyproject.toml`
-- Keeps your environment isolated and PEP 621 compliant
+- Target selector: `assets`, `asset-groups` (default), or `manual` (the "Custom query" contract is restricted to
+  `manual`).
+- Target property selector (for assets / asset groups): `automatic` (default), `seen_ip`, `local_ip` (first), or
+  `hostname`.
 
-#### Commands Summary:
-The table below summarizes the installation and run commands for different workflows (pip or Poetry, prod/current/dev).
+| Target property   | Asset field used                            |
+|-------------------|---------------------------------------------|
+| Automatic         | Hostnames and IPs collected from the assets |
+| Seen IP           | `endpoint_seen_ip`                          |
+| Local IP (first)  | First entry in `endpoint_ips`               |
+| Hostname          | `endpoint_hostname`                         |
 
-| Installation    | Install Command                              | Run Command                                                           | Notes                                                    |
-|-----------------|----------------------------------------------|-----------------------------------------------------------------------|----------------------------------------------------------|
-| Pip Prod        | `pip install .[prod]`                        | `python -m shodan` / `ShodanInjector` (Requires venv active)          | Installs stable dependencies, venv managed automatically |
-| Pip Current     | `pip install .[current]`                     | `python -m shodan` / `ShodanInjector` (Requires venv active)          | Installs latest release from Git                         |
-| Pip Dev/Test    | `pip install -r requirements.txt`            | `python -m shodan` / `ShodanInjector` (Requires venv active)          | Handles local editable client-python + dev/test extras   |
-| Poetry Prod     | `poetry install --extras prod`               | `poetry run ShodanInjector` / `ShodanInjector` (Requires venv active) | Installs stable dependencies, venv managed automatically |
-| Poetry Current  | `poetry install --extras current`            | `poetry run ShodanInjector` / `ShodanInjector` (Requires venv active) | Installs latest release from Git                         |
-| Poetry Dev/Test | `poetry run pip install -r requirements.txt` | `poetry run ShodanInjector` / `ShodanInjector` (Requires venv active) | Handles local editable client-python + dev/test extras   |
+The resolved hostnames or IP addresses are not scanned directly; they are used as the value of the Shodan filter for the
+chosen contract (hostname-based contracts use the hostnames, IP Enumeration uses the IP addresses). Asset groups are
+expanded with the shared `injector_common` pagination helper. In manual mode, the values come from the contract's own
+fields instead (hostname, IP, vulnerability, custom query, etc.).
 
----
+When "Auto-Create assets" is enabled, the injector extracts hostnames, IPs and platform information from the Shodan
+responses, deduplicates them (by hostname, platform and architecture) and returns them as structured assets.
 
 ## Behavior
 
-For the Shodan injector, we have 7 contracts available.
+```mermaid
+flowchart LR
+    O[OpenAEV inject] -->|job via RabbitMQ| I(Shodan injector)
+    I -->|resolve targets| T[Assets / Asset groups / Manual]
+    I -->|GET shodan/host/search| S[Shodan REST API]
+    S -->|matches| I
+    I -->|report + optional assets| O
+```
 
-- Specific behavior for all contracts:
-    - For each contract that has the hostnames and organization fields
-        - For each hostname entered in the hostname field, a dedicated API call will be made with its associated wildcard.
-            - Example: `hostname:filigran.io,*.filigran.io` (wildcard)
-        - If left empty, the organization is automatically derived from each hostname. Otherwise, the specified organization is applied to all hostnames.
-    - Once all calls have been made, a final API call is made to retrieve user information, including the remaining quota.
+On each job the injector acknowledges reception, normalizes and validates the input data, resolves the targets, builds
+and sends the Shodan search request(s) (rate-limited and retried with exponential backoff), optionally builds structured
+assets from the matches, fetches the account quota, and returns a formatted report with a success or error status.
 
-### Supported Contracts
+## Debugging
 
-- Cloud Provider Asset Discovery
-- Critical Ports And Exposed Admin Interface
-- Custom Query
-- CVE Enumeration
-- CVE Specific Watchlist (The only contract that requires a plan Shodan only available to academic users, Small Business API subscribers, and higher.)
-- Domain Discovery
-- IP Enumeration
+Set `INJECTOR_LOG_LEVEL=debug` (or `info`) for verbose logs covering normalization, target resolution and each API call.
+Common issues:
 
-### Target Selection
+- Missing or invalid `SHODAN_API_KEY`: the injector cannot authenticate against Shodan (API keys are stripped from
+  logged URLs).
+- `HTTP 429 Too Many Requests`: lower `SHODAN_API_LEAKY_BUCKET_RATE` / `SHODAN_API_LEAKY_BUCKET_CAPACITY` or raise
+  `SHODAN_API_RETRY` / `SHODAN_API_BACKOFF`.
+- The "CVE specific watchlist" contract relies on the `vuln` filter, which requires an eligible Shodan plan (academic,
+  Small Business API subscribers and higher).
 
-Targets are selected based on the `target_selector` field.
+## Additional information
 
-#### If target type is **Assets** / **Asset-Groups**:
-
-| Selected Property | Uses Asset Field           |
-|-------------------|----------------------------|
-| Automatic         | Automatic                  |
-| Seen IP           | endpoint_seen_ip           |
-| Local IP          | First IP from endpoint_ips |
-| Hostname          | endpoint_hostname          |
-
-#### If target type is **Manual**:
-
-Direct values separated by commas or spaces between IP addresses or hostnames are used.
-
-### Fields available in manual mode by contract
-
-- Cloud Provider Asset Discovery (Search Shodan Endpoint: `/shodan/host/search`)
-    - The `Cloud Provider` field must contain one or more cloud providers, separated by commas.
-    - The `Hostname` field must contain one or more hostnames, separated by commas.
-    - The `Organization` field must contain one or more organizations, separated by commas.
-
-    | Field          | Mandatory | Default / Notes                       |
-    |----------------|-----------|---------------------------------------|
-    | Cloud Provider | Yes       | `Google,Microsoft,Amazon,Azure`       |
-    | Hostname       | Yes       | /                                     |
-    | Organization   | No        | If empty, the hostname value is used. |
-
-- Critical Ports And Exposed Admin Interface (Search Shodan Endpoint: `/shodan/host/search`)
-    - The `Port` field must contain one or more ports, separated by commas.
-    - The `Hostname` field must contain one or more hostnames, separated by commas.
-    - The `Organization` field must contain one or more organizations, separated by commas.
-    
-    | Field        | Mandatory   | Default / Notes                                                                     |
-    |--------------|-------------|-------------------------------------------------------------------------------------|
-    | Port         | Yes         | `20,21,22,23,25,53,80,110,111,135,139,143,443,445,993,995,1723,3306,3389,5900,8080` |
-    | Hostname     | Yes         | /                                                                                   |
-    | Organization | No          | If empty, the hostname value is used.                                               |
-
-- Custom Query (Search Shodan Endpoint: `/shodan/host/search` + your custom query)
-    - You can find all available filters here: https://beta.shodan.io/search/filters
-    -  Note that spaces and commas are important. You must use the same formatting as in the Shodan search bar.
-      - `Spaces = AND` / `Commas = OR`
-
-    | Field        | Mandatory | Default / Notes                         |
-    |--------------|-----------|-----------------------------------------|
-    | Custom Query | Yes       | /                                       |
-
-- CVE Enumeration (Search Shodan Endpoint: `/shodan/host/search`)
-    - The `Hostname` field must contain one or more hostnames, separated by commas.
-    - The `Organization` field must contain one or more organizations, separated by commas.
-  
-    | Field        | Mandatory | Default / Notes                       |
-    |--------------|-----------|---------------------------------------|
-    | Hostname     | Yes       | /                                     |
-    | Organization | No        | If empty, the hostname value is used. |
-
-- CVE Specific Watchlist (Search Shodan Endpoint: `/shodan/host/search`)
-    - Warning : The only contract that requires a plan Shodan only available to academic users, Small Business API subscribers, and higher.
-    - The `Vulnerability` field must contain one or more specific CVEs.
-    - The `Hostname` field must contain one or more hostnames, separated by commas.
-    - The `Organization` field must contain one or more organizations, separated by commas.
-
-    | Field         | Mandatory | Default / Notes                       |
-    |---------------|-----------|---------------------------------------|
-    | Vulnerability | Yes       | /                                     |                           
-    | Hostname      | Yes       | /                                     |                           
-    | Organization  | No        | If empty, the hostname value is used. |                        
-
-- Domain Discovery (Search Shodan Endpoint: `/shodan/host/search`)
-    - The `Hostname` field must contain one or more hostnames, separated by commas.
-    - The `Organization` field must contain one or more organizations, separated by commas.
-
-    | Field        | Mandatory | Default / Notes                       |
-    |--------------|-----------|---------------------------------------|
-    | Hostname     | Yes       | /                                     | 
-    | Organization | No        | If empty, the hostname value is used. |
-
-- IP Enumeration (Search Shodan Endpoint: `/shodan/host/search`)
-    - The `IP` field must contain one or more valid IPv4 addresses.
-     
-    | Field | Mandatory | Default / Notes |
-    |-------|-----------|-----------------|
-    | IP    | Yes       | /               | 
-
----
-
-### Output Trace Message
-The injector captures the fields filled in by the user and analyzes the JSON output of the Shodan response, 
-then returns several sections in the report if successful:
-
-- **Section Title** – Contains the title of the report and the date and time it was created.
-- **Section Config** – Groups all the configuration information entered by the user for the current contract.
-- **Section Info** – Makes an additional final call to the Shodan API to determine the user's remaining quota and plan.
-- **Section External API** – Processes information from Shodan API responses based on the contract and fields filled in. This section also includes:
-  - Call Success – List of successful calls + As well as various other relevant information related to API calls.
-  - Call Failed – List of failed calls + As well as various other relevant information related to API calls.
-- **Section Table** – Visually displays the details of each call, based on the configuration defined for the contract in the injector.
-- **Section JSON** – JSON return of the response directly (In the case of a "custom query", we return the JSON directly rather than the table section.)
-
-### Auto-Create Assets
-This feature automatically creates structured Asset objects (when auto_create_assets is enabled in the UI) from
-Shodan API responses by extracting hostnames, IP addresses, and platform information.
-It supports multiple Shodan response formats depending on the contract type and normalizes the data into a unified
-structure. Assets are then grouped (hostname, platform, and architecture) to prevent duplicates while merging associated
-IP addresses.
-
-### Rate Limiting and Retry
-
-#### Overview
-
-The Shodan API does not publicly document strict rate-limiting rules or request thresholds.
-However, to ensure stable and reliable interactions with the API, a rate-limiting and retry mechanism is implemented.
-
-These mechanisms aim to:
-- Smooth the flow of outgoing requests,
-- Reduce the risk of HTTP 429 Too Many Requests responses,
-- Handle transient failures,
-- Improve the clarity of error reporting in output traces message.
-
-#### Rate limiting 
-
-A rate-limiting mechanism is applied to control the frequency of API calls.
-Requests are deliberately paced to avoid sending bursts of traffic that could exceed Shodan’s internal limits or trigger protective measures.
-
-This approach helps:
-- Prevent temporary blocking or throttling,
-- Ensure consistent behavior across multiple API calls,
-- Maintain predictable execution when processing multiple hostnames or IPs.
-
-There are two environment variables for controlling the flow:
-- `SHODAN_API_LEAKY_BUCKET_RATE` - Controls the rate at which API requests are allowed to be executed.
-- `SHODAN_API_LEAKY_BUCKET_CAPACITY` - Defines the maximum burst size allowed before requests are delayed.
-
-#### Retry strategy
-
-A retry mechanism is applied to handle failed API requests.
-Requests are retried after a short delay to mitigate transient failures and improve execution stability.
-
-This approach helps:
-- Automatically retry failed requests up to a limited number of attempts.
-- Introduce delays between retries to avoid repeated immediate failures.
-
-There are two environment variables for controlling the flow:
-- `SHODAN_API_RETRY` - Defines the maximum number of retry attempts for a failed request.
-- `SHODAN_API_BACKOFF` - Specifies the maximum delay (in seconds) applied between retry attempts, using an exponential backoff strategy.
-
-#### Execution trace and feedback
-
-Each API call is tracked individually.
-The success or failure of each request is reported in the external API section of the output trace message.
-
-Once all API calls related to the host name or IP address have been made, a final API call is executed to retrieve user information, including the remaining API quota.
-
----
-
-## Resources
-
-**Filigran**
-- Homepage: https://filigran.io/
-- Repository: https://github.com/OpenAEV-Platform/injectors/tree/main/shodan
-- Documentation: https://github.com/OpenAEV-Platform/injectors/tree/main/shodan/README.md
-- Issues: https://github.com/OpenAEV-Platform/injectors/issues
-
-**Shodan**
-- Homepage: https://www.shodan.io/
-- Register Page: https://account.shodan.io/register
-- REST API Documentation: https://developer.shodan.io/api
+- Shodan website: [https://www.shodan.io/](https://www.shodan.io/)
+- Shodan REST API documentation: [https://developer.shodan.io/api](https://developer.shodan.io/api)
+- Shodan search filters: [https://www.shodan.io/search/filters](https://www.shodan.io/search/filters)
+- Create a Shodan account / API key: [https://account.shodan.io/register](https://account.shodan.io/register)

--- a/teams/README.md
+++ b/teams/README.md
@@ -1,252 +1,173 @@
 # OpenAEV Microsoft Teams Injector
 
-The **OpenAEV Teams Injector** allows OpenAEV to send notifications to Microsoft Teams channels through HTTP-based
-integrations (typically via Power Automate).
+The Microsoft Teams injector lets OpenAEV post a message to a Microsoft Teams channel as part of attack scenarios. It
+does not call the Microsoft Teams APIs directly: instead it sends an HTTP POST to a Power Automate
+("When an HTTP request is received") workflow, which posts the message into the channel on your behalf. It exposes a
+single inject contract that takes the workflow URL, a title and a message, and reports whether the notification was
+delivered.
 
 ## Table of Contents
 
-* [OpenAEV Teams Injector](#openaev-microsoft-teams-injector)
+- [OpenAEV Microsoft Teams Injector](#openaev-microsoft-teams-injector)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [How it works](#how-it-works)
+  - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenAEV environment variables](#openaev-environment-variables)
+    - [Base injector environment variables](#base-injector-environment-variables)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+    - [Set up the Power Automate workflow](#set-up-the-power-automate-workflow)
+  - [Inject contracts](#inject-contracts)
+  - [Behavior](#behavior)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
 
-    * [Prerequisites](#prerequisites)
-    * [Configuration](#configuration)
+## Introduction
 
-        * [OpenAEV Environment Variables](#openaev-environment-variables)
-        * [Injector Environment Variables](#injector-environment-variables)
-    * [Deployment](#deployment)
+OpenAEV (Breach and Attack Simulation) drives injectors to execute the technical actions of a scenario. The Microsoft
+Teams injector registers a single message contract with the OpenAEV platform; when an inject using this contract is
+played, OpenAEV dispatches a job to the injector, which posts `{"title": ..., "message": ...}` to the Power Automate
+workflow URL provided in the inject. The workflow is then responsible for posting the message into the target Teams
+chat or channel.
 
-        * [Docker Deployment](#docker-deployment)
-        * [Manual Deployment](#manual-deployment)
-    * [Development](#development)
-    * [Behavior](#behavior)
+## How it works
 
-        * [Power Automate Workflow Requirements](#power-automate-workflow-requirements)
-        * [Use Cases](#use-cases)
+Injectors receive their jobs through the message broker (RabbitMQ) configured by the OpenAEV platform. The injector
+fetches the broker connection details from OpenAEV at startup, so it only needs to be able to reach the OpenAEV URL and
+the RabbitMQ host/port advertised by the platform. To deliver a message, the injector also needs outbound HTTP access to
+the Power Automate workflow URL.
 
-## Prerequisites
+## Requirements
 
-This injector communicates with the OpenAEV platform through **RabbitMQ**, using the configuration provided by OpenAEV.
+- A running OpenAEV platform, reachable from the injector (along with its RabbitMQ broker)
+- A Microsoft Teams channel and a Power Automate workflow exposing an HTTP trigger (see
+  [Set up the Power Automate workflow](#set-up-the-power-automate-workflow))
+- No additional system binaries are required
+- For a manual (non-Docker) deployment:
+  - Python >= 3.11 and [Poetry](https://python-poetry.org/) >= 2.1
 
-To function properly, the injector **must be able to reach the RabbitMQ service** (hostname and port) defined in the
-OpenAEV configuration.
+## Configuration variables
 
-## Configuration
+The injector is configured either through environment variables (recommended, read from `docker-compose.yml` / the
+`.env` file for a Docker deployment) or through a `config.yml` file (for a manual deployment). Copy the provided
+`.env.sample` / `config.yml.sample` and fill in the values flagged with `ChangeMe`.
 
-Configuration values can be provided either:
+### OpenAEV environment variables
 
-* via `docker-compose.yml` (Docker deployment), or
-* via `config.yml` (manual deployment).
+| Parameter     | config.yml      | Docker environment variable | Mandatory | Description                                                                      |
+|---------------|-----------------|-----------------------------|-----------|----------------------------------------------------------------------------------|
+| OpenAEV URL   | `openaev.url`   | `OPENAEV_URL`               | Yes       | The URL of the OpenAEV platform. Must be reachable from where the injector runs. |
+| OpenAEV Token | `openaev.token` | `OPENAEV_TOKEN`             | Yes       | The administrator token of the OpenAEV platform.                                 |
 
-### OpenAEV Environment Variables
+### Base injector environment variables
 
-The following parameters are required to connect the injector to the OpenAEV platform:
-
-| Parameter     | `config.yml` | Docker Variable | Mandatory | Description                                         |
-|---------------|--------------|-----------------|-----------|-----------------------------------------------------|
-| OpenAEV URL   | `url`        | `OPENAEV_URL`   | Yes       | Base URL of the OpenAEV platform.                   |
-| OpenAEV Token | `token`      | `OPENAEV_TOKEN` | Yes       | Admin API token configured in the OpenAEV platform. |
-
-### Injector Environment Variables
-
-The following parameters control the injector runtime behavior:
-
-| Parameter     | `config.yml` | Docker Variable      | Default | Mandatory | Description                                             |
-|---------------|--------------|----------------------|---------|-----------|---------------------------------------------------------|
-| Injector ID   | `id`         | `INJECTOR_ID`        | —       | Yes       | Unique `UUIDv4` identifying this injector instance.     |
-| Injector Name | `name`       | `INJECTOR_NAME`      | —       | Yes       | Human-readable name of the injector.                    |
-| Log Level     | `log_level`  | `INJECTOR_LOG_LEVEL` | `info`  | Yes       | Logging verbosity: `debug`, `info`, `warn`, or `error`. |
+| Parameter     | config.yml           | Docker environment variable | Default | Mandatory | Description                                                     |
+|---------------|----------------------|-----------------------------|---------|-----------|-----------------------------------------------------------------|
+| Injector ID   | `injector.id`        | `INJECTOR_ID`               | /       | Yes       | A unique `UUIDv4` identifier for this injector instance.        |
+| Injector Name | `injector.name`      | `INJECTOR_NAME`             | Teams   | No        | The name of the injector as shown in OpenAEV.                   |
+| Log Level     | `injector.log_level` | `INJECTOR_LOG_LEVEL`        | info    | No        | Verbosity of the logs. One of `debug`, `info`, `warn`, `error`. |
 
 ## Deployment
 
 ### Docker Deployment
 
-Build the Docker image using the provided `Dockerfile`:
+This injector depends on the shared `injector_common` package, so the image must be built with a build context that
+exposes it:
 
 ```shell
 docker build --build-context injector_common=../injector_common . -t openaev/injector-teams:latest
 ```
-```shell
-podman build --build-context injector_common=../injector_common . -t openaev/injector-teams:latest
-```
 
-Then configure the environment variables in `docker-compose.yml` and start the injector:
+Create a `.env` file from `.env.sample` and fill in your values, then start the injector with the provided
+`docker-compose.yml`:
 
 ```shell
 docker compose up -d
 ```
 
-```shell
-podman compose up -d
-```
-
----
-
-#### Domain name resolution - Local openAEV with Injector container
-**Note:** If you are running OpenAEV locally on your host machine and want to run this injector inside a Docker container, the `openaev` URL defined in `config.yml` and `.env` must be reachable from inside the container.
-
-Inside a container, `localhost` refers to the container itself - not your host machine. Therefore, you cannot use `localhost` as the OpenAEV URL unless OpenAEV is running inside the same container.
-
-Instead, use: `host.docker.internal`. This hostname allows the container to access services running on your host machine.
-
-**In short**:
-- `localhost` -> container itself
-- `host.docker.internal` -> your host machine
-
-**Platform-specific notes**:
-- **macOS / Windows (Docker Desktop):**     
-  `host.docker.internal` works out of the box. No additional configuration is needed.
-- **Linux:**  
-  You must explicitly map it using `extra_hosts`:
-```yaml
-services:
-  your-injector-name:
-    image: your-image-name
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-```
-
-**Important**:
-- Avoid mapping `host.docker.internal` to a fixed IP (e.g. `1.2.3.4`) unless you have a specific reason. The host IP can change, and Docker provides `host-gateway` to handle this dynamically.
-- Make sure your OpenAEV service is listening on `0.0.0.0` (not just `localhost`), otherwise it may NOT be accessible from the container.
-
----
+> If OpenAEV runs on your host machine while the injector runs in a container, set `OPENAEV_URL` to
+> `http://host.docker.internal:<port>` rather than `localhost`. On Linux, also add
+> `extra_hosts: ["host.docker.internal:host-gateway"]` to the service, and make sure OpenAEV listens on `0.0.0.0`.
 
 ### Manual Deployment
 
-1. Create a `config.yml` file based on `config.yml.sample`
-2. Adjust the configuration values to match your environment
-
-#### Requirements
-
-* Python package manager **Poetry** (version 2.1 or later)
-  👉 [https://python-poetry.org/](https://python-poetry.org/)
-
-#### Installation
-
-**Production environment**
+Create a `config.yml` from `config.yml.sample`, then install and run the injector:
 
 ```shell
 poetry install
-```
-
-**Development environment**
-
-For development, you should first clone the `pyoaev` repository following the instructions provided in the OpenAEV
-documentation.
-
-Install development dependencies
-
-```shell
-poetry install --extras dev
-```
-
-## Development
-
-This project follows strict code formatting rules to ensure consistency and readability across the OpenAEV ecosystem.
-
-Before submitting any **Pull Request**, contributors **must** format the codebase using **isort** and **black**.
-
-### Code Formatting
-
-The following tools are required (already included in the development dependencies):
-
-* **isort** – import sorting
-* **black** – code formatter
-
-Run them from the project root:
-
-```shell
-poetry run isort --profile black .
-poetry run black .
-```
-
-Both commands must complete **without errors or changes** before opening a PR.
-
-> ⚠️ Pull Requests that do not respect formatting rules may be rejected or require additional review cycles.
-
-#### Run the Injector
-
-```shell
 poetry run python -m teams.openaev_teams
 ```
 
+> For local development against a checkout of [client-python](https://github.com/OpenAEV-Platform/client-python)
+> (cloned next to this repository), use `poetry install --extras dev`.
+
+## Usage
+
+Once started, the injector registers its contract with OpenAEV and waits for jobs. Add a Teams inject to a scenario or
+atomic testing, paste the Power Automate URL, set the title and message, and play it: the injector posts the message to
+the workflow and the inject is marked successful once the workflow returns an HTTP 2xx response.
+
+### Set up the Power Automate workflow
+
+The injector posts a JSON body to a Power Automate workflow rather than to Microsoft Teams directly. Create the workflow
+once, then reuse its URL in your injects:
+
+1. In [Power Automate](https://make.powerautomate.com/), create a new cloud flow with the trigger
+   **When an HTTP request is received**.
+2. Provide a request body JSON schema with two string properties, `title` and `message` (this is exactly what the
+   injector sends).
+3. Add the Microsoft Teams action **Post message in a chat or channel**, posting as **Flow bot** to the target team and
+   channel. Map the message content to the `title` and `message` values coming from the trigger.
+4. Save the flow. Power Automate generates an **HTTP POST URL** - copy it and paste it into the inject's
+   `Power Automate URL` field.
+
+![Power Automate workflow](assets/workflow.png)
+
+![Request body and message mapping](assets/body_message.png)
+
+## Inject contracts
+
+| Contract                | Fields                                          | Action                                                       |
+|-------------------------|-------------------------------------------------|--------------------------------------------------------------|
+| Teams - Channel message | Power Automate URL (`uri`), Title, Message      | HTTP POST `{"title": ..., "message": ...}` to the Power Automate URL |
+
+All three fields are mandatory:
+
+- `Power Automate URL` (`uri`): the HTTP trigger URL of the Power Automate workflow.
+- `Title`: the message title sent in the JSON body.
+- `Message`: the message body (multi-line text area) sent in the JSON body.
+
+The contract returns no structured outputs. The inject is marked `SUCCESS` when the workflow replies with an HTTP 2xx
+status, and `ERROR` otherwise (including on a request timeout, 5 seconds by default).
+
 ## Behavior
 
-This injector introduces **Microsoft Teams-specific inject contracts** in OpenAEV.
+```mermaid
+flowchart LR
+    O[OpenAEV inject] -->|job via RabbitMQ| I(Teams injector)
+    I -->|HTTP POST title + message| W[Power Automate workflow]
+    W -->|Post message as Flow bot| C[Microsoft Teams channel]
+    W -->|HTTP status| I
+    I -->|success / error| O
+```
 
-Each inject results in:
+On each job the injector acknowledges reception, validates that the contract is the Teams message contract, builds the
+`{"title": ..., "message": ...}` payload from the inject content, and POSTs it to the Power Automate URL. It then reports a
+success or error status back to OpenAEV based on the HTTP response.
 
-* an HTTP `POST` request,
-* a JSON payload,
-* targeting a **Power Automate HTTP trigger**, which then posts a message into a Microsoft Teams channel.
+## Debugging
 
-The injector reports execution status and metadata back to OpenAEV after completion.
+Set `INJECTOR_LOG_LEVEL=debug` for more verbose logs. The most common issues are an incorrect or expired Power Automate
+URL, or the injector being unable to reach it (network/proxy restrictions): both surface as an `ERROR` execution status
+with the HTTP status code or the request error in the execution message.
 
-## Power Automate Workflow Requirements
+## Additional information
 
-⚠️ **This injector only works with a specific type of Power Automate workflow.**
-
-The injector **does not send messages directly to Microsoft Teams**.
-It relies on **Power Automate** to expose an HTTP endpoint and forward messages to Teams.
-
-### Supported Workflow Type
-
-Only **Cloud flows** using the following trigger are supported:
-
-> **When an HTTP request is received**
-
-This trigger:
-
-* Exposes an HTTP `POST` endpoint
-* Accepts a JSON payload sent by the injector
-* Allows posting messages to Teams using built-in actions
-
-Other workflow types (scheduled flows, Teams-triggered flows, etc.) **are not compatible**.
-
-### Minimal Workflow Structure
-
-The Power Automate flow must follow this structure:
-
-1. **Trigger**
-
-    * *When an HTTP request is received*
-
-2. **Optional**
-
-    * *Initialize variable* (used to store or manipulate the request body)
-
-3. **Action**
-
-    * *Post a message in a chat or channel*
-    * Posted as **Flow bot**
-    * Targeting a **Team** and **Channel**
-    * Message content mapped from the HTTP payload
-
-### Expected Payload
-
-The injector sends a JSON payload containing at least:
-
-* `title` – Message title (e.g. alert name, exercise start)
-* `message` – Main message content
-
-These fields must be explicitly mapped in the **Post a message** action.
-
-### Important Notes
-
-* The HTTP endpoint URL generated by Power Automate **must be reachable** by the injector
-* Authentication relies solely on the webhook URL
-* Message formatting (emojis, layout, icons) is handled **inside Power Automate**
-* The flow must be **saved and published** after any change
-
-## Use Cases
-
-### Supported Power Automate Workflow Example
-
-Work with this kind of Power Automate workflow:
-
-![Power Automate Workflow](./assets/workflow.png)
-
-### Message Body Mapping Example
-
-Example of message body configuration in the **Post a message in a chat or channel** step:
-
-![Body message](./assets/body_message.png)
+- Power Automate - the "When an HTTP request is received" trigger:
+  [https://learn.microsoft.com/training/modules/http-connectors/4-http-request](https://learn.microsoft.com/training/modules/http-connectors/4-http-request)
+- Microsoft Teams - Power Automate flows:
+  [https://support.microsoft.com/office/use-power-automate-in-microsoft-teams-c4ad99e5-6c9a-4d44-8a35-c8d2c4b7af8b](https://support.microsoft.com/office/use-power-automate-in-microsoft-teams-c4ad99e5-6c9a-4d44-8a35-c8d2c4b7af8b)


### PR DESCRIPTION
## Summary

- Rewrite all 8 injector READMEs (ai-redteam, aws, http-query, netexec, nmap, nuclei, shodan, teams) to a single standardized structure aligned with the collector documentation: Introduction, How it works, Requirements, Configuration variables, Deployment, Usage, Inject contracts, Target selection, Behavior, Debugging and Additional information, with accurate configuration tables, deployment and run commands (including the `injector_common` build context where required) and a behavior diagram.
- Incorporates review feedback: point the Teams docs to the cloud-flow "When an HTTP request is received" trigger instead of the unrelated Power Automate Desktop Flows HTTP action reference; clarify that the Nuclei "TEMPLATES Scan" contract passes `-templates /` as the template path Nuclei runs against rather than a special "all templates" selector; and use valid JSON object notation (`{"title": ..., "message": ...}`) consistently in the Teams README.

## Test plan

- [x] Rendered READMEs reviewed on GitHub
- [x] CI (formatting, linter, tests, build) is green

Closes #284
