### PR TITLE
fix(netexec): missing expectation types in contracts (#301)

### DIFF
--- a/netexec/netexec/contracts/base_fields.py
+++ b/netexec/netexec/contracts/base_fields.py
@@ -112,12 +112,26 @@ def build_core_fields() -> list[ContractElement]:
         cardinality=ContractCardinality.Multiple,
         predefinedExpectations=[
             Expectation(
+                expectation_type=ExpectationType.detection,
+                expectation_name="Detection",
+                expectation_description="",
+                expectation_score=100,
+                expectation_expectation_group=False,
+            ),
+            Expectation(
+                expectation_type=ExpectationType.prevention,
+                expectation_name="Prevention",
+                expectation_description="",
+                expectation_score=100,
+                expectation_expectation_group=False,
+            ),
+            Expectation(
                 expectation_type=ExpectationType.vulnerability,
                 expectation_name="Not vulnerable",
                 expectation_description="",
                 expectation_score=100,
                 expectation_expectation_group=False,
-            )
+            ),
         ],
     )
 


### PR DESCRIPTION
### Proposed changes

* Adding prevention and detection to the predefined expectation types in the output contracts

### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Closes #301 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...-->