### PR TITLE
ci(injectors): build and publish the ai-redteam injector (#303)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,14 +244,14 @@ workflows:
       - test:
           matrix:
             parameters:
-              injector_name: ["http-query", "netexec", "nmap", "nuclei"]
+              injector_name: ["ai-redteam", "http-query", "netexec", "nmap", "nuclei"]
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*/
       - build_docker_images:
           matrix:
             parameters:
-              injector_name: [ "aws", "http-query", "netexec", "nmap", "nuclei", "shodan", "teams" ]
+              injector_name: [ "ai-redteam", "aws", "http-query", "netexec", "nmap", "nuclei", "shodan", "teams" ]
           requires:
             - ensure_formatting
             - linter
@@ -262,7 +262,7 @@ workflows:
       - publish_images:
           matrix:
             parameters:
-              injector_name: [ "aws", "http-query", "netexec", "nmap", "nuclei", "shodan", "teams" ]
+              injector_name: [ "ai-redteam", "aws", "http-query", "netexec", "nmap", "nuclei", "shodan", "teams" ]
           requires:
             - build_docker_images
           filters:


### PR DESCRIPTION
Closes #303

## Summary

- Wires the `ai-redteam` injector into the CircleCI pipeline. It existed in the repo but was
  absent from every CI matrix, so `openaev/injector-ai-redteam` was never built or published,
  which made it undeployable from the platform marketplace catalog.

## Changes

Adds `ai-redteam` to the three hardcoded matrices in `.circleci/config.yml`:
- `test` (it ships a test suite)
- `build_docker_images`
- `publish_images`

## Test plan

- [ ] CircleCI `test` job runs the ai-redteam unit tests.
- [ ] `build_docker_images` builds `openaev/injector-ai-redteam:${CIRCLE_SHA1}`.
- [ ] On `main`, `publish_images` pushes `openaev/injector-ai-redteam:rolling` (and
      `openbas/injector-ai-redteam:rolling`).

## Follow-up

These matrices are maintained by hand, which is how this drift happened. Consider discovering
injectors automatically (as `test-injectors.yml` already does for tests) so build/publish can
no longer miss a connector.
