### PR TITLE
fix(aws): predefine Prevention expectation alongside Detection (#346)

### DIFF
--- a/aws/aws/contracts_aws.py
+++ b/aws/aws/contracts_aws.py
@@ -144,7 +144,15 @@ class AWSContracts:
                 expectation_score=100,
                 expectation_expectation_group=False,
                 expectation_is_predefined=True,
-            )
+            ),
+            Expectation(
+                expectation_type=ExpectationType.prevention,
+                expectation_name="Prevention",
+                expectation_description="",
+                expectation_score=100,
+                expectation_expectation_group=False,
+                expectation_is_predefined=True,
+            ),
         ]
         expectations = ContractExpectations(
             key="expectations",


### PR DESCRIPTION
Closes #346

## Summary

The AWS Exploitation injector predefined only a Detection expectation. As a cloud breach / exploitation injector it should also predefine Prevention, so atomic testings created from its contracts propose both Detection and Prevention by default (matching nmap, netexec, stratus, teams, http-query, ...).

## Change

- `aws/aws/contracts_aws.py`: add a predefined `ExpectationType.prevention` ("Prevention", score 100, `expectation_is_predefined=True`) next to the existing Detection expectation.

## Context / dependency

The reason predefined expectations were missing on the platform at all is an upstream pyoaev regression (the `availableExpectations` rename dropped the field-level `predefinedExpectations` array the platform reads). That is fixed in client-python PR OpenBAS-Platform/client-python#310. This PR is the injector-side follow-up.

Audit of the other injectors (no change needed):
- Already predefine detection + prevention (+ vulnerability where relevant): ai-redteam, http-query, nmap, nuclei, netexec, stratus, teams.
- Recon / attack-surface OSINT scanners intentionally predefine vulnerability only (no endpoint execution to detect/prevent): censys, shodan.

## Test plan

- `black` / `isort` clean on the changed file.
- Contract still builds; the expectations field now carries two predefined items.
