### PR TITLE
docs: standardize censys, stratus and root READMEs (#348)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,31 @@ The following repository is used to store the OpenAEV injectors for the platform
 
 This repository is used to host injectors that are supported by the core development team of OpenAEV. Nevertheless, the community is also developing a lot of injectors, third-parties modules directly linked to OpenAEV. You can find the list of all available injectors and plugins in the [OpenAEV ecosystem dedicated space](https://filigran.notion.site/OpenAEV-Ecosystem-30d8eb73d7d04611843e758ddef8941b).
 
+## Development
+This step installs all injectors within the repository inside a single poetry environment. If you do not wish
+to work with all injectors at once, it is possible to install each injector within its own poetry environment. Refer
+to each injector's individual README for instructions.
+
+In this repository, you need to have `python >= 3.11` and `poetry >= 2.1`. Install the development environment with:
+> [!IMPORTANT]
+> This repository uses "mutually exclusive extra markers" to manage the source of the pyoaev dependency. Make sure to
+> follow the steps to set up poetry correctly to handle this case:
+> https://python-poetry.org/docs/dependency-specification/#exclusive-extras
+
+```shell
+poetry install --extras dev
+```
+
 ### Creating a new injector
 
 #### Project setup
-Assuming a new collector by the name of `new_injector`, create a skeleton directory with:
+Assuming a new injector by the name of `new_injector`, create a skeleton directory with:
 ```shell
 poetry new new_injector
 ```
 
 #### `pyoaev` dependency
-We wish to retain the possibility to develop simultaneously on `pyoaev` and collectors. We rely on PEP 508 environment
+We wish to retain the possibility to develop simultaneously on `pyoaev` and injectors. We rely on PEP 508 environment
 markers to alternatively install a local path `pyoaev` dependency or a released version from PyPI; specifically the `extra`
 marker.
 
@@ -32,7 +47,7 @@ vim new_injector/pyproject.toml
 Here's the expression for the pyoaev dependency, including the `extra` definition:
 ```toml
 dependencies = [
-    "pyoaev (==2.1.8); extra != 'dev'",
+    "pyoaev (==<latest pyoaev release on PyPI>); extra != 'dev'",
 ]
 [project.optional-dependencies]
 dev = [
@@ -59,10 +74,17 @@ Here's an example layout:
 │   ├── scripts
 │   └── test
 └── injectors          <= this repo root dir
+    ├── ai-redteam
     ├── aws
+    ├── censys
     ├── http-query
+    ├── injector_common
+    ├── netexec
     ├── nmap
-    └── nuclei
+    ├── nuclei
+    ├── shodan
+    ├── stratus
+    └── teams
 ```
 
 
@@ -72,7 +94,7 @@ If you want to help use improve or develop new injector, please check out the **
 
 ## License
 
-**Unless specified otherwise**, injectors are released under the [Apache 2.0](https://github.com/OpenAEV-Platform/injectors/blob/master/LICENSE). If an injector is released by its author under a different license, the subfolder corresponding to it will contain a *LICENSE* file.
+**Unless specified otherwise**, injectors are released under the [Apache 2.0](https://github.com/OpenAEV-Platform/injectors/blob/main/LICENSE). If an injector is released by its author under a different license, the subfolder corresponding to it will contain a *LICENSE* file.
 
 ## About
 

--- a/censys/README.md
+++ b/censys/README.md
@@ -1,31 +1,183 @@
 # OpenAEV Censys Injector
 
-Queries the [Censys](https://censys.io/) Search API to discover an
-organization's external attack surface - exposed hosts, open ports and
-certificates - complementing the existing Shodan injector.
+The Censys injector lets OpenAEV run external attack-surface OSINT discovery as part of attack scenarios using the
+[Censys](https://censys.io/) Search API. It exposes ready-to-use inject contracts (host search and certificate search),
+runs the query you provide against the Censys Search API v2, and reports the discovered hosts, open ports and
+certificate fingerprints back to OpenAEV as structured findings. It complements the Shodan injector for external
+reconnaissance.
 
-## Contracts
+## Table of Contents
 
-- Censys - Host search: returns matching hosts (IPv4) and distinct ports as
-  findings.
-- Censys - Certificate search: returns matching certificate fingerprints.
+- [OpenAEV Censys Injector](#openaev-censys-injector)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [How it works](#how-it-works)
+  - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenAEV environment variables](#openaev-environment-variables)
+    - [Base injector environment variables](#base-injector-environment-variables)
+    - [Censys injector environment variables](#censys-injector-environment-variables)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+  - [Inject contracts](#inject-contracts)
+  - [Target selection](#target-selection)
+  - [Behavior](#behavior)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
 
-## Credentials
+## Introduction
 
-Censys Search API credentials (`CENSYS_API_ID`, `CENSYS_API_SECRET`) are
-injector-level operator credentials configured in `config.yml`/`.env`, never
-logged.
+OpenAEV (Breach and Attack Simulation) drives injectors to execute the technical actions of a scenario. The Censys
+injector registers a set of discovery contracts with the OpenAEV platform; when an inject using one of these contracts
+is played, OpenAEV dispatches a job to the injector, which runs the provided query against the Censys Search API and
+returns the results.
 
-## Development
+## How it works
 
-```bash
-poetry install
-poetry run python -m unittest
+Injectors receive their jobs through the message broker (RabbitMQ) configured by the OpenAEV platform. The injector
+fetches the broker connection details from OpenAEV at startup, so it only needs to be able to reach the OpenAEV URL and
+the RabbitMQ host/port advertised by the platform. At execution time, it also needs outbound access to the Censys
+Search API.
+
+## Requirements
+
+- A running OpenAEV platform, reachable from the injector (along with its RabbitMQ broker).
+- Censys Search API credentials (`CENSYS_API_ID`, `CENSYS_API_SECRET`) and outbound network access to
+  `https://search.censys.io`.
+- No additional system binaries are required: the Censys API is called with the Python `requests` library.
+- The Docker image must be built with `--build-context injector_common=../injector_common`, because the injector depends
+  on the shared `injector_common` package located one level above this directory.
+- For a manual (non-Docker) deployment:
+  - Python >= 3.11 and [Poetry](https://python-poetry.org/) >= 2.1.
+
+## Configuration variables
+
+The injector is configured either through environment variables (recommended, read from `docker-compose.yml` / the
+`.env` file for a Docker deployment) or through a `config.yml` file (for a manual deployment). Copy the provided
+`.env.sample` / `config.yml.sample` and fill in the values flagged with `ChangeMe`.
+
+### OpenAEV environment variables
+
+| Parameter         | config.yml          | Docker environment variable | Mandatory | Description                                                                        |
+|-------------------|---------------------|-----------------------------|-----------|------------------------------------------------------------------------------------|
+| OpenAEV URL       | `openaev.url`       | `OPENAEV_URL`               | Yes       | The URL of the OpenAEV platform. Must be reachable from where the injector runs.   |
+| OpenAEV Token     | `openaev.token`     | `OPENAEV_TOKEN`             | Yes       | The administrator token of the OpenAEV platform.                                   |
+| OpenAEV Tenant ID | `openaev.tenant_id` | `OPENAEV_TENANT_ID`         | No        | Tenant identifier for multi-tenant deployments. When set, it must be a valid UUID. |
+
+### Base injector environment variables
+
+| Parameter     | config.yml           | Docker environment variable | Default | Mandatory | Description                                                     |
+|---------------|----------------------|-----------------------------|---------|-----------|-----------------------------------------------------------------|
+| Injector ID   | `injector.id`        | `INJECTOR_ID`               | /       | Yes       | A unique `UUIDv4` identifier for this injector instance.        |
+| Injector Name | `injector.name`      | `INJECTOR_NAME`             | Censys  | No        | The name of the injector as shown in OpenAEV.                   |
+| Log Level     | `injector.log_level` | `INJECTOR_LOG_LEVEL`        | error   | No        | Verbosity of the logs. One of `debug`, `info`, `warn`, `error`. |
+
+### Censys injector environment variables
+
+| Parameter       | config.yml          | Docker environment variable | Default                      | Mandatory | Description                                                                     |
+|-----------------|---------------------|-----------------------------|------------------------------|-----------|---------------------------------------------------------------------------------|
+| API ID          | `censys.api_id`     | `CENSYS_API_ID`             | /                            | Yes       | Censys Search API ID (operator credential).                                     |
+| API Secret      | `censys.api_secret` | `CENSYS_API_SECRET`         | /                            | Yes       | Censys Search API secret (operator credential).                                 |
+| Base URL        | `censys.base_url`   | `CENSYS_BASE_URL`           | `https://search.censys.io`   | No        | Base URL of the Censys Search API.                                              |
+| Results per page| `censys.per_page`   | `CENSYS_PER_PAGE`           | 50                           | No        | Number of results requested per page (Censys max: 100).                         |
+| Max pages       | `censys.max_pages`  | `CENSYS_MAX_PAGES`          | 10                           | No        | Maximum number of result pages to follow via the Censys cursor (bounds usage).  |
+
+> The Censys Search API credentials are injector-level operator credentials configured in `config.yml` / `.env`; they
+> are never logged.
+
+## Deployment
+
+### Docker Deployment
+
+This injector depends on the shared `injector_common` package, so the image must be built with a build context that
+exposes it:
+
+```shell
+docker build --build-context injector_common=../injector_common . -t openaev/injector-censys:latest
 ```
 
-## Icon
+Create a `.env` file from `.env.sample` and fill in your values (including `CENSYS_API_ID` and `CENSYS_API_SECRET`),
+then start the injector with the provided `docker-compose.yml`:
 
-`censys_injector/img/icon-censys.png` currently ships as a square opaque
-512x512 placeholder; it must be replaced with genuine Censys brand artwork
-following the injector icon standard (square 1:1, 512x512 PNG, solid opaque
-background) - tracked by OpenAEV-Platform/injectors#305.
+```shell
+docker compose up -d
+```
+
+> If OpenAEV runs on your host machine while the injector runs in a container, set `OPENAEV_URL` to
+> `http://host.docker.internal:<port>` rather than `localhost`. On Linux, also add
+> `extra_hosts: ["host.docker.internal:host-gateway"]` to the service, and make sure OpenAEV listens on `0.0.0.0`.
+
+### Manual Deployment
+
+Create a `config.yml` from `config.yml.sample` (set at least `censys.api_id` and `censys.api_secret`), then install and
+run the injector:
+
+```shell
+poetry install
+poetry run python -m censys_injector.openaev_censys
+```
+
+> For local development against a checkout of [client-python](https://github.com/OpenAEV-Platform/client-python)
+> (cloned next to this repository), use `poetry install --extras dev`.
+
+## Usage
+
+Once started, the injector registers its contracts with OpenAEV and waits for jobs. Add a Censys inject to a scenario or
+atomic testing, choose the contract (host search or certificate search), enter a Censys search query, and play it: the
+results are attached to the inject once the search completes.
+
+Each contract exposes a single mandatory `Censys search query` field plus expectations. The query uses the standard
+[Censys search syntax](https://search.censys.io/search/language), for example `services.service_name: HTTP` for hosts or
+`parsed.subject.organization: Example` for certificates.
+
+## Inject contracts
+
+All contracts share the label "Censys" and the `NETWORK` security domain. Each contract issues the corresponding Censys
+Search API v2 request and returns finding-compatible outputs.
+
+| Contract                   | Censys API endpoint              | Outputs                                                      |
+|----------------------------|----------------------------------|-------------------------------------------------------------|
+| Censys - Host search       | `GET /api/v2/hosts/search`       | `hosts` (matching IPv4 addresses), `ports` (distinct ports) |
+| Censys - Certificate search| `GET /api/v2/certificates/search`| `certificates` (matching SHA-256 fingerprints)              |
+
+Results are paginated through the Censys cursor: the injector follows the `result.links.next` token up to `max_pages`
+pages (with `per_page` results per page) to bound API usage on broad queries.
+
+## Target selection
+
+This injector does not target OpenAEV assets. The "target" of every inject is the Censys search query provided in the
+`query` field, so there is no asset / asset-group / manual selector and no target-property mapping. Scope the search
+with the Censys query syntax instead.
+
+## Behavior
+
+```mermaid
+flowchart LR
+    O[OpenAEV inject] -->|job via RabbitMQ| I(Censys injector)
+    I -->|GET hosts/certificates search| S[Censys Search API v2]
+    S -->|paginated hits| I
+    I -->|hosts + ports / certificates| O
+```
+
+On each job the injector acknowledges reception, reads the search query from the inject, calls the matching Censys
+Search API v2 endpoint (following the cursor across pages), extracts the hosts and ports (host search) or the
+certificate fingerprints (certificate search), and returns a structured result together with a success or error status.
+
+## Debugging
+
+Set `INJECTOR_LOG_LEVEL=debug` for more verbose logs. Common issues:
+
+- Authentication failures (`HTTP 401`/`403`): verify `CENSYS_API_ID` and `CENSYS_API_SECRET` and that the account has
+  Search API access.
+- `HTTP 429 Too Many Requests`: you are exceeding your Censys rate limit; lower `CENSYS_PER_PAGE` / `CENSYS_MAX_PAGES` or
+  reduce how often the inject runs.
+- No results: confirm the query is valid Censys search syntax for the selected data set (hosts vs. certificates).
+
+## Additional information
+
+- Censys website: [https://censys.io/](https://censys.io/)
+- Censys Search API documentation: [https://search.censys.io/api](https://search.censys.io/api)
+- Censys search language: [https://search.censys.io/search/language](https://search.censys.io/search/language)
+- Create Censys API credentials: [https://search.censys.io/account/api](https://search.censys.io/account/api)

--- a/stratus/README.md
+++ b/stratus/README.md
@@ -1,62 +1,214 @@
 # OpenAEV Stratus Red Team Injector
 
-Emulates granular cloud and container adversary techniques using
-[Stratus Red Team](https://stratus-red-team.cloud/). A single injector exposes
-**one contract per Stratus technique**, so attack scenarios are organized by
-capability (each specific TTP is a directly selectable inject) rather than split
-across one injector per cloud.
+The Stratus Red Team injector lets OpenAEV emulate granular cloud and container adversary techniques as part of attack
+scenarios using [Stratus Red Team](https://stratus-red-team.cloud/) by DataDog. It exposes **one inject contract per
+Stratus technique** (across AWS, Azure, Entra ID, GCP, Kubernetes and Amazon EKS), plus a per-platform "custom
+technique" contract, detonates the technique with automatic cleanup so no live infrastructure is left behind, and
+reports the result back to OpenAEV. Each technique contract is tagged with its MITRE ATT&CK technique ids where Stratus
+declares them, and every inject raises detection and prevention expectations that runtime detection collectors can
+later validate.
 
-## Contracts
+## Table of Contents
 
-- One contract per Stratus technique (99 in the pinned release), each tagged
-  with its MITRE ATT&CK technique ids where Stratus declares them. The technique
-  is fixed by the contract; the operator only provides the platform credentials.
-- One "Detonate a custom Stratus technique" contract per platform, which takes a
-  free-form technique id so any technique in the pinned Stratus release can be
-  run even before a dedicated contract exists.
+- [OpenAEV Stratus Red Team Injector](#openaev-stratus-red-team-injector)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [How it works](#how-it-works)
+  - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenAEV environment variables](#openaev-environment-variables)
+    - [Base injector environment variables](#base-injector-environment-variables)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+  - [Inject contracts](#inject-contracts)
+  - [Supported platforms](#supported-platforms)
+  - [Target selection](#target-selection)
+  - [Behavior](#behavior)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
 
-The technique catalog in `stratus/contracts/techniques.py` is generated from the
-Stratus Red Team source (`internal/attacktechniques`).
+## Introduction
 
-## Supported platforms
-
-Each technique belongs to one platform, which determines the credentials:
-
-| Platform | Credentials |
-|---|---|
-| AWS | Access key id / secret, optional session token, region |
-| Azure | Tenant / subscription / client id / client secret |
-| Entra ID | Tenant / client id / client secret |
-| Google Cloud Platform | Project id + service account key (JSON) |
-| Kubernetes | Kubeconfig (YAML) |
-| Amazon EKS | AWS access key id / secret, optional session token, region |
+OpenAEV (Breach and Attack Simulation) drives injectors to execute the technical actions of a scenario. The Stratus Red
+Team injector registers a catalog of cloud attack techniques with the OpenAEV platform; when an inject using one of
+these contracts is played, OpenAEV dispatches a job to the injector, which detonates the matching Stratus technique
+against the cloud account behind the credentials provided in the inject, and returns the result. Attack scenarios are
+therefore organized by capability - each specific TTP is a directly selectable inject rather than being split across one
+injector per cloud.
 
 ## How it works
 
-- The injector resolves the target platform and technique from the contract id
-  (fixed-technique contracts) or from the inject content (custom contracts),
-  builds the Stratus process environment, and detonates the technique with
-  `--cleanup` so no live infrastructure is left behind.
-- SUCCESS/ERROR is reported to the platform; DETECTION/PREVENTION expectations
-  are scored by the relevant runtime detection collectors.
+Injectors receive their jobs through the message broker (RabbitMQ) configured by the OpenAEV platform. The injector
+fetches the broker connection details from OpenAEV at startup, so it only needs to be able to reach the OpenAEV URL and
+the RabbitMQ host/port advertised by the platform. To detonate a technique, the injector runs the bundled `stratus`
+binary, which provisions the technique's prerequisites (via Terraform) in the target cloud, detonates the attack and
+then cleans up - so it needs outbound access to the target cloud provider's APIs.
 
-## Credentials
+## Requirements
 
-Credentials are provided per inject through the contract fields. Secrets that
-Stratus reads from disk (GCP service account key, kubeconfig) are written to a
-temp file only for the detonation, restricted to the owner, and removed
-afterwards (including on the failure path). Credentials are never persisted in
-`config.yml`/`.env` and never logged.
+- A running OpenAEV platform, reachable from the injector (along with its RabbitMQ broker).
+- Cloud credentials for the platform you want to test - supplied per inject, not on the injector (see
+  [Target selection](#target-selection)).
+- The `stratus` binary must be available on the `PATH`. The Docker image downloads and verifies a pinned Stratus release
+  (`v2.24.0` at the time of writing, checksum-verified during the build).
+- The Docker image must be built with `--build-context injector_common=../injector_common`, because the injector depends
+  on the shared `injector_common` package located one level above this directory.
+- For a manual (non-Docker) deployment:
+  - Python >= 3.11 and [Poetry](https://python-poetry.org/) >= 2.1.
+  - The `stratus` binary installed and on the `PATH` (see the
+    [Stratus Red Team installation guide](https://stratus-red-team.cloud/getting-started/)).
 
-## Development
+## Configuration variables
 
-```bash
-poetry install
-poetry run python -m unittest
+The injector is configured either through environment variables (recommended, read from `docker-compose.yml` / the
+`.env` file for a Docker deployment) or through a `config.yml` file (for a manual deployment). Copy the provided
+`.env.sample` / `config.yml.sample` and fill in the values flagged with `ChangeMe`.
+
+Cloud credentials are not part of the injector configuration: they are supplied per inject (see
+[Target selection](#target-selection)).
+
+### OpenAEV environment variables
+
+| Parameter         | config.yml          | Docker environment variable | Mandatory | Description                                                                        |
+|-------------------|---------------------|-----------------------------|-----------|------------------------------------------------------------------------------------|
+| OpenAEV URL       | `openaev.url`       | `OPENAEV_URL`               | Yes       | The URL of the OpenAEV platform. Must be reachable from where the injector runs.   |
+| OpenAEV Token     | `openaev.token`     | `OPENAEV_TOKEN`             | Yes       | The administrator token of the OpenAEV platform.                                   |
+| OpenAEV Tenant ID | `openaev.tenant_id` | `OPENAEV_TENANT_ID`         | No        | Tenant identifier for multi-tenant deployments. When set, it must be a valid UUID. |
+
+### Base injector environment variables
+
+| Parameter     | config.yml           | Docker environment variable | Default          | Mandatory | Description                                                     |
+|---------------|----------------------|-----------------------------|------------------|-----------|-----------------------------------------------------------------|
+| Injector ID   | `injector.id`        | `INJECTOR_ID`               | /                | Yes       | A unique `UUIDv4` identifier for this injector instance.        |
+| Injector Name | `injector.name`      | `INJECTOR_NAME`             | Stratus Red Team | No        | The name of the injector as shown in OpenAEV.                   |
+| Log Level     | `injector.log_level` | `INJECTOR_LOG_LEVEL`        | error            | No        | Verbosity of the logs. One of `debug`, `info`, `warn`, `error`. |
+
+## Deployment
+
+### Docker Deployment
+
+This injector depends on the shared `injector_common` package, so the image must be built with a build context that
+exposes it:
+
+```shell
+docker build --build-context injector_common=../injector_common . -t openaev/injector-stratus:latest
 ```
 
-## Icon
+Create a `.env` file from `.env.sample` and fill in your values, then start the injector with the provided
+`docker-compose.yml`:
 
-`stratus/img/icon-stratus.png` is the official Stratus Red Team badge flattened
-onto a solid opaque background, per the injector icon standard
-(OpenAEV-Platform/injectors#305).
+```shell
+docker compose up -d
+```
+
+> The Docker image already bundles the pinned `stratus` binary, so no further installation is needed inside the
+> container.
+
+> If OpenAEV runs on your host machine while the injector runs in a container, set `OPENAEV_URL` to
+> `http://host.docker.internal:<port>` rather than `localhost`. On Linux, also add
+> `extra_hosts: ["host.docker.internal:host-gateway"]` to the service, and make sure OpenAEV listens on `0.0.0.0`.
+
+### Manual Deployment
+
+Make sure the `stratus` binary is installed and on your `PATH`, create a `config.yml` from `config.yml.sample`, then
+install and run the injector:
+
+```shell
+poetry install
+poetry run python -m stratus.openaev_stratus
+```
+
+> For local development against a checkout of [client-python](https://github.com/OpenAEV-Platform/client-python)
+> (cloned next to this repository), use `poetry install --extras dev`.
+
+## Usage
+
+Once started, the injector registers its contracts with OpenAEV and waits for jobs. Add a Stratus inject to a scenario
+or atomic testing, pick the technique contract for the platform you want to test (or the platform's "Detonate a custom
+Stratus technique" contract), fill in the platform credentials, then play it: the detonation result is attached to the
+inject once it completes.
+
+## Inject contracts
+
+The injector exposes two families of contracts, all under the `Stratus Red Team` label and the `CLOUD` security domain.
+Every contract carries its platform's credential fields (see [Supported platforms](#supported-platforms)) and
+predefined detection / prevention expectations (score 100 each).
+
+- **One contract per Stratus technique** (99 in the pinned release). The technique is fixed by the contract - the
+  operator only provides the platform credentials - and the contract is tagged with the technique's MITRE ATT&CK
+  technique ids where Stratus declares them. The contract label is `<Platform> - <Technique name>`.
+- **One "Detonate a custom Stratus technique" contract per platform** (6 total). It adds a free-form
+  `Stratus technique id` field (e.g. `aws.persistence.iam-backdoor-user`) so any technique in the pinned Stratus release
+  can be run even before a dedicated per-technique contract exists.
+
+The technique catalog in `stratus/contracts/techniques.py` is auto-generated from the Stratus Red Team source
+(`internal/attacktechniques`); regenerate it when the pinned Stratus release changes. Each contract returns the
+detonated `technique` id as a structured output.
+
+## Supported platforms
+
+Each technique belongs to one platform, which determines the credential fields shown on the contract. Credentials are
+provided per inject; secrets that Stratus reads from disk (the GCP service account key, the kubeconfig) are written to a
+temporary file only for the detonation, restricted to the owner (`0600`), and removed afterwards (including on the
+failure path). Credentials are never persisted in `config.yml` / `.env` and never logged.
+
+| Platform              | Credential fields                                                                            |
+|-----------------------|----------------------------------------------------------------------------------------------|
+| AWS                   | Access key ID, secret access key, optional session token, region (default `us-east-1`)       |
+| Azure                 | Tenant ID, subscription ID, service principal client ID, client secret                       |
+| Entra ID              | Tenant ID, application (client) ID, client secret, optional subscription ID                  |
+| Google Cloud Platform | Project ID, service account key (JSON, materialized to a temp file for the run)              |
+| Kubernetes            | Kubeconfig (YAML, materialized to a temp file for the run)                                    |
+| Amazon EKS            | AWS access key ID, secret access key, optional session token, region                         |
+
+## Target selection
+
+This injector does not target OpenAEV assets. The "target" of every inject is the cloud account reached through the
+credentials carried by the inject itself. The injector builds the Stratus process environment from those credentials
+(direct environment variables, or a temp file for file-based secrets) for the duration of the detonation only.
+
+As a result, there is no asset / asset-group / manual selector and no target-property mapping. The blast radius of each
+inject is whatever the supplied credentials are entitled to do on the target platform.
+
+## Behavior
+
+```mermaid
+flowchart LR
+    O[OpenAEV inject] -->|job via RabbitMQ| I(Stratus injector)
+    I -->|resolve platform + technique| R[Contract registry]
+    I -->|per-inject credentials| E[Process environment]
+    I -->|stratus detonate --cleanup| S[Stratus Red Team CLI]
+    S -->|warm-up + detonate + cleanup| C[Cloud account]
+    S -->|result| I
+    I -->|success / error + detection / prevention| O
+```
+
+On each job the injector acknowledges reception, resolves the platform and technique from the contract id (or from the
+inject content for a custom contract), builds the Stratus process environment from the per-inject credentials, and
+detonates the technique with `--cleanup` (a 15-minute timeout covers the Terraform warm-up). It then reports
+`SUCCESS` / `ERROR` to the platform; the detection and prevention expectations are scored by the relevant runtime
+detection collectors. Materialized secret files are always removed afterwards, including on the failure path.
+
+## Debugging
+
+Set `INJECTOR_LOG_LEVEL=debug` (or `info`) to log the resolved technique and the `stratus` command line being executed.
+Common issues:
+
+- `stratus binary not found in the injector image`: for manual deployments, make sure `stratus` is installed and on the
+  `PATH`.
+- `No Stratus technique id provided` / `Unsupported contract ...`: for a custom contract, provide a valid technique id;
+  otherwise the stored inject references a contract this injector version does not know.
+- Authentication or permission errors in the detonation output: verify the platform credentials and that the identity is
+  entitled to provision and detonate the technique's prerequisites.
+- A run that times out after 15 minutes returns a timeout error - typically a slow or blocked Terraform warm-up.
+
+## Additional information
+
+- Stratus Red Team website: [https://stratus-red-team.cloud/](https://stratus-red-team.cloud/)
+- Stratus Red Team source: [https://github.com/DataDog/stratus-red-team](https://github.com/DataDog/stratus-red-team)
+- Attack technique catalog: [https://stratus-red-team.cloud/attack-techniques/list/](https://stratus-red-team.cloud/attack-techniques/list/)
+- MITRE ATT&CK: [https://attack.mitre.org/](https://attack.mitre.org/)
+- Techniques detonate real (though benign) actions against real cloud accounts; only run them against environments where
+  that is acceptable.


### PR DESCRIPTION
## Proposed changes

Full-tree README audit to bring every injector's documentation to the same
best-in-class, standardized level already used across the repository (and
mirrored from the `collectors` repo). Two injectors added after the
standardization landed (#284 / #285) had not adopted that structure, and the
root README had drifted.

### `censys/README.md` (full rewrite)

- Adopts the standardized structure (Introduction, How it works, Requirements,
  Configuration variables, Deployment, Usage, Inject contracts, Target
  selection, Behavior, Debugging, Additional information) with a Table of
  Contents.
- Documents the two contracts (Host search, Certificate search), the Censys env
  vars (`CENSYS_API_ID`, `CENSYS_API_SECRET`, and the optional `base_url`,
  `per_page`, `max_pages`), Docker and manual deployment, a behavior diagram and
  debugging tips.
- Removes the stale "Icon" placeholder note (it contradicted
  `censys/censys_injector/img/README.md`; the icon is the genuine brand mark).

### `stratus/README.md` (full rewrite)

- Adopts the standardized structure with a Table of Contents.
- Documents the per-technique contracts (99 in the pinned release) and the
  per-platform custom-technique contracts, the supported platforms and their
  credential fields, the temp-file secret handling, the bundled `stratus`
  binary, Docker and manual deployment, a behavior diagram and debugging tips.
- Removes the stale "Icon" note.

### Root `README.md`

- Fixes the "Assuming a new collector by the name of `new_injector`" typo.
- Completes the example repository layout (adds `ai-redteam`, `censys`,
  `injector_common`, `netexec`, `shodan`, `stratus`, `teams`).
- Removes the hardcoded stale pinned `pyoaev` version from the dependency
  snippet.
- Adds a Development section (matching the `collectors` root README).
- Points the license link at `main` (the default branch).

## Related issues

Closes #348

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes are documentation-only and accurate against the current code
- [x] I have verified the described contracts, env vars and behavior against the
      injector source
