### PR TITLE
feat(injectors): declare Filigran as contract author and align manifest metadata (#355)

### DIFF
--- a/ai-redteam/ai_redteam/configuration/config_loader.py
+++ b/ai-redteam/ai_redteam/configuration/config_loader.py
@@ -21,6 +21,8 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": c.INJECTOR_TYPE},
                 "injector_contracts": {"data": build_contracts()},
+                # Source-declared publisher of this injector's contracts.
+                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
                 "injector_request_timeout_seconds": {

--- a/aws/aws/configuration/config_loader.py
+++ b/aws/aws/configuration/config_loader.py
@@ -21,6 +21,8 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_aws"},
                 "injector_contracts": {"data": AWSContracts.build_contract()},
+                # Source-declared publisher of this injector's contracts.
+                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/aws/manifest-metadata.json
+++ b/aws/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "Amazon Web Service",
   "slug": "openaev_aws",
-  "description": "This Injector use the credentials provided to enumerate through contract the AWS ressources like S3, IAM, Lambda, CloudTrail, Route53, etc. ",
-  "short_description": "Use OpenAEV to perform AWS assessment through credentials sets",
+  "description": "Use the provided AWS credentials to enumerate and assess AWS resources - S3, IAM, Lambda, CloudTrail, Route 53 and more - to surface cloud misconfigurations and exposure.",
+  "short_description": "Assess AWS resources with a set of credentials",
   "use_cases": ["Technical"],
   "verified": true,
   "last_verified_date": "",

--- a/censys/censys_injector/configuration/config_loader.py
+++ b/censys/censys_injector/configuration/config_loader.py
@@ -22,6 +22,8 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_censys"},
                 "injector_contracts": {"data": CensysContracts.build_contract()},
+                # Source-declared publisher of this injector's contracts.
+                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/http-query/http_query/configuration/config_loader.py
+++ b/http-query/http_query/configuration/config_loader.py
@@ -20,6 +20,8 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_http_query"},
                 "injector_contracts": {"data": HttpContracts.build_contract()},
+                # Source-declared publisher of this injector's contracts.
+                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/http-query/manifest-metadata.json
+++ b/http-query/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "HTTP query",
   "slug": "openaev_http_query",
-  "description": "Allow OAEV to perform HTTP queries",
-  "short_description": "Allow OAEV to perform HTTP queries",
+  "description": "Send arbitrary HTTP requests from OpenAEV to interact with web services and APIs - useful for custom checks, webhooks and lightweight attack simulation.",
+  "short_description": "Send custom HTTP requests to web services and APIs",
   "use_cases": ["Technical"],
   "verified": true,
   "last_verified_date": "",

--- a/netexec/netexec/configuration/config_loader.py
+++ b/netexec/netexec/configuration/config_loader.py
@@ -26,6 +26,8 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_netexec"},
                 "injector_contracts": {"data": build_all_contracts()},
+                # Source-declared publisher of this injector's contracts.
+                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/nmap/manifest-metadata.json
+++ b/nmap/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "Nmap: The network mapper",
   "slug": "openaev_nmap",
-  "description": "Allow OAEV to perform nmap scans",
-  "short_description": "Allow OAEV to perform nmap scans",
+  "description": "Run Nmap scans from OpenAEV to discover live hosts, open ports and running services on your targets, feeding reconnaissance findings into simulations.",
+  "short_description": "Run Nmap network and port scans",
   "use_cases": ["Technical"],
   "verified": true,
   "last_verified_date": "",

--- a/nmap/nmap/configuration/config_loader.py
+++ b/nmap/nmap/configuration/config_loader.py
@@ -21,6 +21,8 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_nmap"},
                 "injector_contracts": {"data": NmapContracts.build_contract()},
+                # Source-declared publisher of this injector's contracts.
+                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/nuclei/manifest-metadata.json
+++ b/nuclei/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "Nuclei",
   "slug": "openaev_nuclei",
-  "description": "Allow to perform CVE scan based on Nuclei",
-  "short_description": "Allow to perform CVE scan based on Nuclei",
+  "description": "Run ProjectDiscovery Nuclei templates from OpenAEV to detect known CVEs and misconfigurations on your targets, turning findings into actionable exposure results.",
+  "short_description": "Run CVE and misconfiguration scans with Nuclei",
   "use_cases": ["Technical"],
   "verified": true,
   "last_verified_date": "",

--- a/nuclei/nuclei/configuration/config_loader.py
+++ b/nuclei/nuclei/configuration/config_loader.py
@@ -36,6 +36,8 @@ class ConfigLoader(SettingsLoader):
                 "injector_contracts": {
                     "data": NucleiContracts.build_static_contracts()
                 },
+                # Source-declared publisher of this injector's contracts.
+                "injector_author": {"data": "Filigran"},
                 "injector_external_contracts_maintenance_schedule_seconds": {
                     "data": self.injector.external_contracts_maintenance_schedule_seconds
                 },

--- a/shodan/manifest-metadata.json
+++ b/shodan/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "Shodan",
   "slug": "openaev_shodan",
-  "description": "Scan for intel in Shodan",
-  "short_description": "Scan for intel in Shodan",
+  "description": "Query Shodan from OpenAEV to gather internet-exposure intelligence on your external assets, including open ports, service banners and known vulnerabilities.",
+  "short_description": "Gather external exposure intelligence from Shodan",
   "use_cases": ["Technical"],
   "verified": true,
   "last_verified_date": "",

--- a/shodan/shodan/models/configs/config_loader.py
+++ b/shodan/shodan/models/configs/config_loader.py
@@ -35,6 +35,8 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_shodan"},
                 "injector_contracts": {"data": ShodanContracts().contracts()},
+                # Source-declared publisher of this injector's contracts.
+                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/slack/slack_injector/configuration/config_loader.py
+++ b/slack/slack_injector/configuration/config_loader.py
@@ -23,6 +23,8 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": self.injector.type},
                 "injector_contracts": {"data": SlackContracts.build()},
+                # Source-declared publisher of this injector's contracts.
+                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/stratus/stratus/configuration/config_loader.py
+++ b/stratus/stratus/configuration/config_loader.py
@@ -19,6 +19,8 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_stratus"},
                 "injector_contracts": {"data": build_all_contracts()},
+                # Source-declared publisher of this injector's contracts.
+                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/teams/manifest-metadata.json
+++ b/teams/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "Microsoft Teams",
   "slug": "openaev_teams",
-  "description": "Send messages and Adaptive Cards to Microsoft Teams channels and chats via the Microsoft Graph API",
-  "short_description": "Send messages and Adaptive Cards to Microsoft Teams via Microsoft Graph",
+  "description": "Send messages and Adaptive Cards to Microsoft Teams channels and chats via the Microsoft Graph API, for table-top exercises and crisis communication injects.",
+  "short_description": "Send messages and Adaptive Cards to Microsoft Teams",
   "use_cases": ["Technical"],
   "verified": true,
   "last_verified_date": "",

--- a/teams/teams/configuration/config_loader.py
+++ b/teams/teams/configuration/config_loader.py
@@ -22,6 +22,8 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": self.injector.type},
                 "injector_contracts": {"data": TeamsContracts.build()},
+                # Source-declared publisher of this injector's contracts.
+                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },


### PR DESCRIPTION
## Related issue

Closes #355

## Summary

- Declare 'Filigran' as the source-declared contract author (injector_author config hint) in all pyoaev-based injectors: ai-redteam, aws, censys, http-query, netexec, nmap, nuclei, shodan, slack, stratus, teams.
- Align manifest-metadata.json descriptions with the platform integrations catalog (aws, http-query, nmap, nuclei, shodan, teams).

The author is transported at registration by pyoaev (OpenAEV-Platform/client-python#312) and the platform attributes every contract of the injector to an organization of this name (OpenAEV-Platform/openaev#6784). Until the next pyoaev release the declaration is inert (ignored by older helpers), so this is fully backward compatible.