### PR TITLE
fix(common): aligning on the new naming scheme "asset_..." (#359)

### DIFF
--- a/injector_common/injector_common/targets.py
+++ b/injector_common/injector_common/targets.py
@@ -170,9 +170,15 @@ class Targets:
                     targets.append(target)
                     ip_to_asset_id_map[target] = asset_id
                 else:
+                    hostname_value = asset.get("asset_hostname") or asset.get(
+                        "endpoint_hostname"
+                    )
+                    ips_value = (
+                        asset.get("asset_ips") or asset.get("endpoint_ips") or []
+                    )
                     helper.injector_logger.warning(
                         f"No valid target found for asset_id={asset.get('asset_id')} "
-                        f"(hostname={asset.get('asset_hostname')}, ips={asset.get('asset_ips')})"
+                        f"(hostname={hostname_value}, ips={ips_value})"
                     )
 
             except Exception as e:
@@ -191,14 +197,14 @@ class Targets:
                 return result
 
         elif selector == "seen_ip":
-            seen_ip = asset.get("asset_seen_ip")
+            seen_ip = asset.get("asset_seen_ip") or asset.get("endpoint_seen_ip")
             if Targets.is_valid_ip(seen_ip):
                 return seen_ip, asset_id
             else:
                 return None
 
         elif selector == "local_ip":
-            asset_ips = asset.get("asset_ips") or []
+            asset_ips = asset.get("asset_ips") or asset.get("endpoint_ips") or []
             # Validate each IP
             for ip in asset_ips:
                 if Targets.is_valid_ip(ip):
@@ -207,7 +213,7 @@ class Targets:
             return None
 
         elif selector == "hostname":
-            hostname = asset.get("asset_hostname")
+            hostname = asset.get("asset_hostname") or asset.get("endpoint_hostname")
             if hostname:
                 return hostname, asset_id
 
@@ -233,9 +239,9 @@ class Targets:
         - Otherwise => first valid IP
         """
         asset_id = asset.get("asset_id")
-        agents = asset.get("asset_agents", [])
-        hostname = asset.get("asset_hostname")
-        asset_ips = asset.get("asset_ips", [])
+        agents = asset.get("asset_agents") or []
+        hostname = asset.get("asset_hostname") or asset.get("endpoint_hostname")
+        asset_ips = asset.get("asset_ips") or asset.get("endpoint_ips") or []
 
         # Case 1: Agentless + hostname
         if not agents and hostname:

--- a/injector_common/injector_common/targets.py
+++ b/injector_common/injector_common/targets.py
@@ -170,15 +170,9 @@ class Targets:
                     targets.append(target)
                     ip_to_asset_id_map[target] = asset_id
                 else:
-                    hostname_value = asset.get("asset_hostname") or asset.get(
-                        "endpoint_hostname"
-                    )
-                    ips_value = (
-                        asset.get("asset_ips") or asset.get("endpoint_ips") or []
-                    )
                     helper.injector_logger.warning(
                         f"No valid target found for asset_id={asset.get('asset_id')} "
-                        f"(hostname={hostname_value}, ips={ips_value})"
+                        f"(hostname={asset.get('asset_hostname')}, ips={asset.get('asset_ips')})"
                     )
 
             except Exception as e:
@@ -197,14 +191,14 @@ class Targets:
                 return result
 
         elif selector == "seen_ip":
-            seen_ip = asset.get("asset_seen_ip") or asset.get("endpoint_seen_ip")
+            seen_ip = asset.get("asset_seen_ip")
             if Targets.is_valid_ip(seen_ip):
                 return seen_ip, asset_id
             else:
                 return None
 
         elif selector == "local_ip":
-            asset_ips = asset.get("asset_ips") or asset.get("endpoint_ips") or []
+            asset_ips = asset.get("asset_ips") or []
             # Validate each IP
             for ip in asset_ips:
                 if Targets.is_valid_ip(ip):
@@ -213,7 +207,7 @@ class Targets:
             return None
 
         elif selector == "hostname":
-            hostname = asset.get("asset_hostname") or asset.get("endpoint_hostname")
+            hostname = asset.get("asset_hostname")
             if hostname:
                 return hostname, asset_id
 
@@ -239,9 +233,9 @@ class Targets:
         - Otherwise => first valid IP
         """
         asset_id = asset.get("asset_id")
-        agents = asset.get("asset_agents") or []
-        hostname = asset.get("asset_hostname") or asset.get("endpoint_hostname")
-        asset_ips = asset.get("asset_ips") or asset.get("endpoint_ips") or []
+        agents = asset.get("asset_agents", [])
+        hostname = asset.get("asset_hostname")
+        asset_ips = asset.get("asset_ips", [])
 
         # Case 1: Agentless + hostname
         if not agents and hostname:

--- a/netexec/README.md
+++ b/netexec/README.md
@@ -189,9 +189,9 @@ Targets are resolved through the shared selection logic of `injector_common`:
 | Target property   | Asset field used                                   |
 |-------------------|----------------------------------------------------|
 | Automatic         | Hostname for agentless assets, else first valid IP |
-| Seen IP           | `endpoint_seen_ip`                                 |
-| Local IP (first)  | First valid entry in `endpoint_ips`                |
-| Hostname          | `endpoint_hostname`                                |
+| Seen IP           | `asset_seen_ip`                                    |
+| Local IP (first)  | First valid entry in `asset_ips`                   |
+| Hostname          | `asset_hostname`                                   |
 
 For manual targets, provide hostnames or IP addresses as comma-separated values. Invalid, loopback and link-local
 addresses are filtered out.

--- a/nmap/README.md
+++ b/nmap/README.md
@@ -128,9 +128,9 @@ Targets are resolved through the shared selection logic of `injector_common`:
 | Target property   | Asset field used                            |
 |-------------------|---------------------------------------------|
 | Automatic         | Hostname for agentless assets, else first valid IP |
-| Seen IP           | `endpoint_seen_ip`                          |
-| Local IP (first)  | First valid entry in `endpoint_ips`         |
-| Hostname          | `endpoint_hostname`                         |
+| Seen IP           | `asset_seen_ip`                             |
+| Local IP (first)  | First valid entry in `asset_ips`            |
+| Hostname          | `asset_hostname`                            |
 
 For manual targets, provide hostnames or IP addresses as comma-separated values. Invalid, loopback and link-local
 addresses are filtered out.

--- a/nuclei/README.md
+++ b/nuclei/README.md
@@ -183,9 +183,9 @@ Targets are resolved through the shared selection logic of `injector_common`:
 | Target property   | Asset field used                                   |
 |-------------------|----------------------------------------------------|
 | Automatic         | Hostname for agentless assets, else first valid IP |
-| Seen IP           | `endpoint_seen_ip`                                 |
-| Local IP (first)  | First valid entry in `endpoint_ips`                |
-| Hostname          | `endpoint_hostname`                                |
+| Seen IP           | `asset_seen_ip`                                    |
+| Local IP (first)  | First valid entry in `asset_ips`                   |
+| Hostname          | `asset_hostname`                                   |
 
 For manual targets, provide hostnames or IP addresses as comma-separated values. Invalid, loopback, unspecified and
 link-local addresses are filtered out.

--- a/shodan/README.md
+++ b/shodan/README.md
@@ -170,9 +170,9 @@ Targets can come from OpenAEV assets or from manual input, selected per inject:
 | Target property   | Asset field used                            |
 |-------------------|---------------------------------------------|
 | Automatic         | Hostnames and IPs collected from the assets |
-| Seen IP           | `endpoint_seen_ip`                          |
-| Local IP (first)  | First entry in `endpoint_ips`               |
-| Hostname          | `endpoint_hostname`                         |
+| Seen IP           | `asset_seen_ip`                             |
+| Local IP (first)  | First entry in `asset_ips`                  |
+| Hostname          | `asset_hostname`                            |
 
 The resolved hostnames or IP addresses are not scanned directly; they are used as the value of the Shodan filter for the
 chosen contract (hostname-based contracts use the hostnames, IP Enumeration uses the IP addresses). Asset groups are

--- a/shodan/shodan/injector/openaev_shodan.py
+++ b/shodan/shodan/injector/openaev_shodan.py
@@ -236,30 +236,39 @@ class ShodanInjector:
                 targets["asset_ids"] = [asset.get("asset_id") for asset in assets]
 
                 targets["hostnames"] = [
-                    asset.get("asset_hostname")
+                    asset.get("asset_hostname") or asset.get("endpoint_hostname")
                     for asset in assets
-                    if asset and asset.get("asset_hostname")
+                    if asset
+                    and (asset.get("asset_hostname") or asset.get("endpoint_hostname"))
                 ]
 
                 targets["ips"] = [
-                    endpoint_ip
+                    asset_ip
                     for asset in assets
-                    for endpoint_ip in (asset.get("asset_ips") or [])
+                    for asset_ip in (
+                        asset.get("asset_ips") or asset.get("endpoint_ips") or []
+                    )
                 ]
 
                 targets["seen_ips"] = [
-                    asset.get("asset_seen_ip")
+                    asset.get("asset_seen_ip") or asset.get("endpoint_seen_ip")
                     for asset in assets
-                    if asset and asset.get("asset_seen_ip")
+                    if asset
+                    and (asset.get("asset_seen_ip") or asset.get("endpoint_seen_ip"))
                 ]
 
                 for asset in assets:
                     targets["assets"].append(
                         {
                             "asset_id": asset.get("asset_id"),
-                            "endpoint_hostname": asset.get("asset_hostname") or None,
-                            "endpoint_ips": asset.get("asset_ips") or [],
-                            "endpoint_seen_ip": asset.get("asset_seen_ip"),
+                            "asset_hostname": asset.get("asset_hostname")
+                            or asset.get("endpoint_hostname")
+                            or None,
+                            "asset_ips": asset.get("asset_ips")
+                            or asset.get("endpoint_ips")
+                            or [],
+                            "asset_seen_ip": asset.get("asset_seen_ip")
+                            or asset.get("endpoint_seen_ip"),
                         }
                     )
 
@@ -267,10 +276,12 @@ class ShodanInjector:
             case "hostname":
                 for asset in assets:
                     asset_id = asset.get("asset_id")
-                    endpoint_hostname = asset.get("asset_hostname")
-                    if endpoint_hostname:
+                    asset_hostname = asset.get("asset_hostname") or asset.get(
+                        "endpoint_hostname"
+                    )
+                    if asset_hostname:
                         targets["asset_ids"].append(asset_id)
-                        targets["hostnames"].append(endpoint_hostname)
+                        targets["hostnames"].append(asset_hostname)
                     else:
                         self.helper.injector_logger.debug(
                             f"{LOG_PREFIX} - The asset ID was ignored because you chose to map to hostname, "
@@ -284,9 +295,9 @@ class ShodanInjector:
                     targets["assets"].append(
                         {
                             "asset_id": asset_id,
-                            "endpoint_hostname": endpoint_hostname,
-                            "endpoint_ips": [],
-                            "endpoint_seen_ip": None,
+                            "asset_hostname": asset_hostname,
+                            "asset_ips": [],
+                            "asset_seen_ip": None,
                         }
                     )
 
@@ -294,16 +305,16 @@ class ShodanInjector:
             case "local_ip":
                 for asset in assets:
                     asset_id = asset.get("asset_id")
-                    endpoint_ips = asset.get("asset_ips")
-                    if endpoint_ips:
+                    asset_ips = asset.get("asset_ips") or asset.get("endpoint_ips")
+                    if asset_ips:
                         targets["asset_ids"].append(asset_id)
-                        targets["ips"].append(endpoint_ips[0])
+                        targets["ips"].append(asset_ips[0])
                         targets["assets"].append(
                             {
                                 "asset_id": asset_id,
-                                "endpoint_hostname": None,
-                                "endpoint_ips": endpoint_ips,
-                                "endpoint_seen_ip": None,
+                                "asset_hostname": None,
+                                "asset_ips": asset_ips,
+                                "asset_seen_ip": None,
                             }
                         )
                     else:
@@ -320,16 +331,18 @@ class ShodanInjector:
             case "seen_ip":
                 for asset in assets:
                     asset_id = asset.get("asset_id")
-                    endpoint_seen_ip = asset.get("asset_seen_ip")
-                    if endpoint_seen_ip:
+                    asset_seen_ip = asset.get("asset_seen_ip") or asset.get(
+                        "endpoint_seen_ip"
+                    )
+                    if asset_seen_ip:
                         targets["asset_ids"].append(asset_id)
-                        targets["seen_ips"].append(endpoint_seen_ip)
+                        targets["seen_ips"].append(asset_seen_ip)
                         targets["assets"].append(
                             {
                                 "asset_id": asset_id,
-                                "endpoint_hostname": None,
-                                "endpoint_ips": [],
-                                "endpoint_seen_ip": endpoint_seen_ip,
+                                "asset_hostname": None,
+                                "asset_ips": [],
+                                "asset_seen_ip": asset_seen_ip,
                             }
                         )
                     else:

--- a/shodan/shodan/injector/openaev_shodan.py
+++ b/shodan/shodan/injector/openaev_shodan.py
@@ -236,39 +236,30 @@ class ShodanInjector:
                 targets["asset_ids"] = [asset.get("asset_id") for asset in assets]
 
                 targets["hostnames"] = [
-                    asset.get("asset_hostname") or asset.get("endpoint_hostname")
+                    asset.get("asset_hostname")
                     for asset in assets
-                    if asset
-                    and (asset.get("asset_hostname") or asset.get("endpoint_hostname"))
+                    if asset and asset.get("asset_hostname")
                 ]
 
                 targets["ips"] = [
                     asset_ip
                     for asset in assets
-                    for asset_ip in (
-                        asset.get("asset_ips") or asset.get("endpoint_ips") or []
-                    )
+                    for asset_ip in (asset.get("asset_ips") or [])
                 ]
 
                 targets["seen_ips"] = [
-                    asset.get("asset_seen_ip") or asset.get("endpoint_seen_ip")
+                    asset.get("asset_seen_ip")
                     for asset in assets
-                    if asset
-                    and (asset.get("asset_seen_ip") or asset.get("endpoint_seen_ip"))
+                    if asset and asset.get("asset_seen_ip")
                 ]
 
                 for asset in assets:
                     targets["assets"].append(
                         {
                             "asset_id": asset.get("asset_id"),
-                            "asset_hostname": asset.get("asset_hostname")
-                            or asset.get("endpoint_hostname")
-                            or None,
-                            "asset_ips": asset.get("asset_ips")
-                            or asset.get("endpoint_ips")
-                            or [],
-                            "asset_seen_ip": asset.get("asset_seen_ip")
-                            or asset.get("endpoint_seen_ip"),
+                            "asset_hostname": asset.get("asset_hostname") or None,
+                            "asset_ips": asset.get("asset_ips") or [],
+                            "asset_seen_ip": asset.get("asset_seen_ip"),
                         }
                     )
 
@@ -276,9 +267,7 @@ class ShodanInjector:
             case "hostname":
                 for asset in assets:
                     asset_id = asset.get("asset_id")
-                    asset_hostname = asset.get("asset_hostname") or asset.get(
-                        "endpoint_hostname"
-                    )
+                    asset_hostname = asset.get("asset_hostname")
                     if asset_hostname:
                         targets["asset_ids"].append(asset_id)
                         targets["hostnames"].append(asset_hostname)
@@ -305,7 +294,7 @@ class ShodanInjector:
             case "local_ip":
                 for asset in assets:
                     asset_id = asset.get("asset_id")
-                    asset_ips = asset.get("asset_ips") or asset.get("endpoint_ips")
+                    asset_ips = asset.get("asset_ips")
                     if asset_ips:
                         targets["asset_ids"].append(asset_id)
                         targets["ips"].append(asset_ips[0])
@@ -331,9 +320,7 @@ class ShodanInjector:
             case "seen_ip":
                 for asset in assets:
                     asset_id = asset.get("asset_id")
-                    asset_seen_ip = asset.get("asset_seen_ip") or asset.get(
-                        "endpoint_seen_ip"
-                    )
+                    asset_seen_ip = asset.get("asset_seen_ip")
                     if asset_seen_ip:
                         targets["asset_ids"].append(asset_id)
                         targets["seen_ips"].append(asset_seen_ip)

--- a/shodan/shodan/models/normalize_input_data.py
+++ b/shodan/shodan/models/normalize_input_data.py
@@ -112,9 +112,9 @@ class ContractType(str, Enum):
 
 class AssetsType(BaseModel):
     asset_id: str
-    endpoint_hostname: str | None
-    endpoint_ips: list[str]
-    endpoint_seen_ip: str | None
+    asset_hostname: str | None
+    asset_ips: list[str]
+    asset_seen_ip: str | None
 
 
 class TargetsType(BaseModel):

--- a/shodan/tests/unit/test_openaev_shodan.py
+++ b/shodan/tests/unit/test_openaev_shodan.py
@@ -1,0 +1,213 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import shodan.injector.openaev_shodan as module
+
+
+@patch.object(module, "ShodanClientAPI")
+class TestShodanInjector(unittest.TestCase):
+    def test_shodaninjector_init(self, m_api):
+        config = MagicMock()
+        helper = MagicMock()
+
+        injector = module.ShodanInjector(config=config, helper=helper)
+
+        self.assertEqual(injector.config, config)
+        self.assertEqual(injector.helper, helper)
+        self.assertEqual(injector.shodan_client_api, m_api.return_value)
+
+        m_api.assert_called_once_with(config, helper)
+
+    def test_shodaninjector_build_targets_from_assets_case_automatic(self, m_api):
+        config = MagicMock()
+        helper = MagicMock()
+
+        injector = module.ShodanInjector(config=config, helper=helper)
+
+        selector_property = "automatic"
+        targets = {
+            "assets": [],
+            "asset_ids": [],
+            "ips": [],
+            "hostnames": [],
+            "seen_ips": [],
+        }
+        asset_zero = {
+            "asset_id": "asset-zero-id",
+            "asset_hostname": "asset.hostname.local",
+            "asset_ips": ["1.2.3.4"],
+            "asset_seen_ip": "1.2.3.4",
+        }
+        asset_one = {
+            "asset_id": "asset-one-id",
+            "endpoint_hostname": "endpoint.hostname.local",
+            "endpoint_ips": ["5.6.7.8"],
+            "endpoint_seen_ip": "5.6.7.8",
+        }
+        assets = [asset_zero, asset_one]
+
+        injector._build_targets_from_assets(selector_property, targets, assets)
+
+        self.assertEqual(targets["asset_ids"], ["asset-zero-id", "asset-one-id"])
+        self.assertEqual(
+            targets["hostnames"], ["asset.hostname.local", "endpoint.hostname.local"]
+        )
+        self.assertEqual(targets["ips"], ["1.2.3.4", "5.6.7.8"])
+        self.assertEqual(targets["seen_ips"], ["1.2.3.4", "5.6.7.8"])
+        self.assertEqual(
+            targets["assets"],
+            [
+                {
+                    "asset_id": "asset-zero-id",
+                    "asset_hostname": "asset.hostname.local",
+                    "asset_ips": ["1.2.3.4"],
+                    "asset_seen_ip": "1.2.3.4",
+                },
+                {
+                    "asset_id": "asset-one-id",
+                    "asset_hostname": "endpoint.hostname.local",
+                    "asset_ips": ["5.6.7.8"],
+                    "asset_seen_ip": "5.6.7.8",
+                },
+            ],
+        )
+
+    def test_shodaninjector_build_targets_from_assets_case_hostname(self, m_api):
+        config = MagicMock()
+        helper = MagicMock()
+
+        injector = module.ShodanInjector(config=config, helper=helper)
+
+        selector_property = "hostname"
+        targets = {
+            "assets": [],
+            "asset_ids": [],
+            "ips": [],
+            "hostnames": [],
+            "seen_ips": [],
+        }
+        asset_zero = {
+            "asset_id": "asset-zero-id",
+            "asset_hostname": "asset.hostname.local",
+        }
+        asset_one = {
+            "asset_id": "asset-one-id",
+            "endpoint_hostname": "endpoint.hostname.local",
+        }
+        assets = [asset_zero, asset_one]
+
+        injector._build_targets_from_assets(selector_property, targets, assets)
+
+        self.assertEqual(targets["asset_ids"], ["asset-zero-id", "asset-one-id"])
+        self.assertEqual(
+            targets["hostnames"], ["asset.hostname.local", "endpoint.hostname.local"]
+        )
+        self.assertEqual(
+            targets["assets"],
+            [
+                {
+                    "asset_id": "asset-zero-id",
+                    "asset_hostname": "asset.hostname.local",
+                    "asset_ips": [],
+                    "asset_seen_ip": None,
+                },
+                {
+                    "asset_id": "asset-one-id",
+                    "asset_hostname": "endpoint.hostname.local",
+                    "asset_ips": [],
+                    "asset_seen_ip": None,
+                },
+            ],
+        )
+
+    def test_shodaninjector_build_targets_from_assets_case_local_ip(self, m_api):
+        config = MagicMock()
+        helper = MagicMock()
+
+        injector = module.ShodanInjector(config=config, helper=helper)
+
+        selector_property = "local_ip"
+        targets = {
+            "assets": [],
+            "asset_ids": [],
+            "ips": [],
+            "hostnames": [],
+            "seen_ips": [],
+        }
+        asset_zero = {
+            "asset_id": "asset-zero-id",
+            "asset_ips": ["1.2.3.4"],
+        }
+        asset_one = {
+            "asset_id": "asset-one-id",
+            "endpoint_ips": ["5.6.7.8"],
+        }
+        assets = [asset_zero, asset_one]
+
+        injector._build_targets_from_assets(selector_property, targets, assets)
+
+        self.assertEqual(targets["asset_ids"], ["asset-zero-id", "asset-one-id"])
+        self.assertEqual(targets["ips"], ["1.2.3.4", "5.6.7.8"])
+        self.assertEqual(
+            targets["assets"],
+            [
+                {
+                    "asset_id": "asset-zero-id",
+                    "asset_hostname": None,
+                    "asset_ips": ["1.2.3.4"],
+                    "asset_seen_ip": None,
+                },
+                {
+                    "asset_id": "asset-one-id",
+                    "asset_hostname": None,
+                    "asset_ips": ["5.6.7.8"],
+                    "asset_seen_ip": None,
+                },
+            ],
+        )
+
+    def test_shodaninjector_build_targets_from_assets_case_seen_ip(self, m_api):
+        config = MagicMock()
+        helper = MagicMock()
+
+        injector = module.ShodanInjector(config=config, helper=helper)
+
+        selector_property = "seen_ip"
+        targets = {
+            "assets": [],
+            "asset_ids": [],
+            "ips": [],
+            "hostnames": [],
+            "seen_ips": [],
+        }
+        asset_zero = {
+            "asset_id": "asset-zero-id",
+            "asset_seen_ip": "1.2.3.4",
+        }
+        asset_one = {
+            "asset_id": "asset-one-id",
+            "endpoint_seen_ip": "5.6.7.8",
+        }
+        assets = [asset_zero, asset_one]
+
+        injector._build_targets_from_assets(selector_property, targets, assets)
+
+        self.assertEqual(targets["asset_ids"], ["asset-zero-id", "asset-one-id"])
+        self.assertEqual(targets["seen_ips"], ["1.2.3.4", "5.6.7.8"])
+        self.assertEqual(
+            targets["assets"],
+            [
+                {
+                    "asset_id": "asset-zero-id",
+                    "asset_hostname": None,
+                    "asset_ips": [],
+                    "asset_seen_ip": "1.2.3.4",
+                },
+                {
+                    "asset_id": "asset-one-id",
+                    "asset_hostname": None,
+                    "asset_ips": [],
+                    "asset_seen_ip": "5.6.7.8",
+                },
+            ],
+        )

--- a/shodan/tests/unit/test_openaev_shodan.py
+++ b/shodan/tests/unit/test_openaev_shodan.py
@@ -40,9 +40,9 @@ class TestShodanInjector(unittest.TestCase):
         }
         asset_one = {
             "asset_id": "asset-one-id",
-            "endpoint_hostname": "endpoint.hostname.local",
-            "endpoint_ips": ["5.6.7.8"],
-            "endpoint_seen_ip": "5.6.7.8",
+            "asset_hostname": "endpoint.hostname.local",
+            "asset_ips": ["5.6.7.8"],
+            "asset_seen_ip": "5.6.7.8",
         }
         assets = [asset_zero, asset_one]
 
@@ -92,7 +92,7 @@ class TestShodanInjector(unittest.TestCase):
         }
         asset_one = {
             "asset_id": "asset-one-id",
-            "endpoint_hostname": "endpoint.hostname.local",
+            "asset_hostname": "endpoint.hostname.local",
         }
         assets = [asset_zero, asset_one]
 
@@ -140,7 +140,7 @@ class TestShodanInjector(unittest.TestCase):
         }
         asset_one = {
             "asset_id": "asset-one-id",
-            "endpoint_ips": ["5.6.7.8"],
+            "asset_ips": ["5.6.7.8"],
         }
         assets = [asset_zero, asset_one]
 
@@ -186,7 +186,7 @@ class TestShodanInjector(unittest.TestCase):
         }
         asset_one = {
             "asset_id": "asset-one-id",
-            "endpoint_seen_ip": "5.6.7.8",
+            "asset_seen_ip": "5.6.7.8",
         }
         assets = [asset_zero, asset_one]
 


### PR DESCRIPTION
### Proposed changes

* ~~Update `injector_common` to handle both previous naming schema (`endpoint_...`) and new naming schema (`asset_...`) when extracting targets and fetching targets info~~
* Updating elements related to the previous naming scheme `endpoint_...` with the new naming scheme `asset_...` (especially `shodan` being not `injector_common`-based)

### Testing Instructions

1. Setup an OAEV stack
2. Connect an updated injector to it
3. Run an atomic testing (e.g. `nmap`)

### Related issues

* Closes #359 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...-->