### PR TITLE
fix(injectors): stop declaring Filigran as external contract author (#373)

### DIFF
--- a/ai-redteam/ai_redteam/configuration/config_loader.py
+++ b/ai-redteam/ai_redteam/configuration/config_loader.py
@@ -21,8 +21,6 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": c.INJECTOR_TYPE},
                 "injector_contracts": {"data": build_contracts()},
-                # Source-declared publisher of this injector's contracts.
-                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
                 "injector_request_timeout_seconds": {

--- a/ai-redteam/ai_redteam/configuration/config_loader.py
+++ b/ai-redteam/ai_redteam/configuration/config_loader.py
@@ -21,6 +21,9 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": c.INJECTOR_TYPE},
                 "injector_contracts": {"data": build_contracts()},
+                # Optional author override; None lets the platform attribute
+                # the contracts to the injector's name.
+                "injector_author": {"data": self.injector.author},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
                 "injector_request_timeout_seconds": {

--- a/ai-redteam/ai_redteam/configuration/injector_config_override.py
+++ b/ai-redteam/ai_redteam/configuration/injector_config_override.py
@@ -19,3 +19,8 @@ class InjectorConfigOverride(ConfigLoaderCollector):
         default=120,
         description="HTTP timeout (seconds) for a single request to an AI target.",
     )
+    author: str | None = Field(
+        default=None,
+        description="Optional author override for this injector's contracts. "
+        "When absent, the platform attributes them to the injector's name.",
+    )

--- a/aws/aws/configuration/config_loader.py
+++ b/aws/aws/configuration/config_loader.py
@@ -21,6 +21,9 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_aws"},
                 "injector_contracts": {"data": AWSContracts.build_contract()},
+                # Optional author override; None lets the platform attribute
+                # the contracts to the injector's name.
+                "injector_author": {"data": self.injector.author},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/aws/aws/configuration/config_loader.py
+++ b/aws/aws/configuration/config_loader.py
@@ -21,8 +21,6 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_aws"},
                 "injector_contracts": {"data": AWSContracts.build_contract()},
-                # Source-declared publisher of this injector's contracts.
-                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/aws/aws/configuration/injector_config_override.py
+++ b/aws/aws/configuration/injector_config_override.py
@@ -15,3 +15,8 @@ class InjectorConfigOverride(ConfigLoaderCollector):
         default="aws/img/icon-aws.png",
         description="Path to the icon file",
     )
+    author: str | None = Field(
+        default=None,
+        description="Optional author override for this injector's contracts. "
+        "When absent, the platform attributes them to the injector's name.",
+    )

--- a/censys/censys_injector/configuration/config_loader.py
+++ b/censys/censys_injector/configuration/config_loader.py
@@ -22,6 +22,9 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_censys"},
                 "injector_contracts": {"data": CensysContracts.build_contract()},
+                # Optional author override; None lets the platform attribute
+                # the contracts to the injector's name.
+                "injector_author": {"data": self.injector.author},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/censys/censys_injector/configuration/config_loader.py
+++ b/censys/censys_injector/configuration/config_loader.py
@@ -22,8 +22,6 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_censys"},
                 "injector_contracts": {"data": CensysContracts.build_contract()},
-                # Source-declared publisher of this injector's contracts.
-                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/censys/censys_injector/configuration/injector_config_override.py
+++ b/censys/censys_injector/configuration/injector_config_override.py
@@ -14,3 +14,8 @@ class InjectorConfigOverride(ConfigLoaderCollector):
         default="censys_injector/img/icon-censys.png",
         description="Path to the icon file",
     )
+    author: str | None = Field(
+        default=None,
+        description="Optional author override for this injector's contracts. "
+        "When absent, the platform attributes them to the injector's name.",
+    )

--- a/email-google-workspace/email_gws_injector/configuration/config_loader.py
+++ b/email-google-workspace/email_gws_injector/configuration/config_loader.py
@@ -24,6 +24,9 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": self.injector.type},
                 "injector_contracts": {"data": EmailGWSContracts.build()},
+                # Optional author override; None lets the platform attribute
+                # the contracts to the injector's name.
+                "injector_author": {"data": self.injector.author},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/email-google-workspace/email_gws_injector/configuration/injector_config_override.py
+++ b/email-google-workspace/email_gws_injector/configuration/injector_config_override.py
@@ -22,3 +22,8 @@ class InjectorConfigOverride(ConfigLoaderCollector):
         description="Determines the verbosity of the logs. Options: debug, info, warn, or error.",
         default="info",
     )
+    author: str | None = Field(
+        default=None,
+        description="Optional author override for this injector's contracts. "
+        "When absent, the platform attributes them to the injector's name.",
+    )

--- a/email-m365/email_m365_injector/configuration/config_loader.py
+++ b/email-m365/email_m365_injector/configuration/config_loader.py
@@ -24,6 +24,9 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": self.injector.type},
                 "injector_contracts": {"data": EmailM365Contracts.build()},
+                # Optional author override; None lets the platform attribute
+                # the contracts to the injector's name.
+                "injector_author": {"data": self.injector.author},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/email-m365/email_m365_injector/configuration/config_loader.py
+++ b/email-m365/email_m365_injector/configuration/config_loader.py
@@ -24,8 +24,6 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": self.injector.type},
                 "injector_contracts": {"data": EmailM365Contracts.build()},
-                # Source-declared publisher of this injector's contracts.
-                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/email-m365/email_m365_injector/configuration/injector_config_override.py
+++ b/email-m365/email_m365_injector/configuration/injector_config_override.py
@@ -22,3 +22,8 @@ class InjectorConfigOverride(ConfigLoaderCollector):
         description="Determines the verbosity of the logs. Options: debug, info, warn, or error.",
         default="info",
     )
+    author: str | None = Field(
+        default=None,
+        description="Optional author override for this injector's contracts. "
+        "When absent, the platform attributes them to the injector's name.",
+    )

--- a/http-query/http_query/configuration/config_loader.py
+++ b/http-query/http_query/configuration/config_loader.py
@@ -20,6 +20,9 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_http_query"},
                 "injector_contracts": {"data": HttpContracts.build_contract()},
+                # Optional author override; None lets the platform attribute
+                # the contracts to the injector's name.
+                "injector_author": {"data": self.injector.author},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/http-query/http_query/configuration/config_loader.py
+++ b/http-query/http_query/configuration/config_loader.py
@@ -20,8 +20,6 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_http_query"},
                 "injector_contracts": {"data": HttpContracts.build_contract()},
-                # Source-declared publisher of this injector's contracts.
-                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/http-query/http_query/configuration/injector_config_override.py
+++ b/http-query/http_query/configuration/injector_config_override.py
@@ -15,3 +15,8 @@ class InjectorConfigOverride(ConfigLoaderCollector):
         default="http-query/img/icon-http.png",
         description="Path to the icon file",
     )
+    author: str | None = Field(
+        default=None,
+        description="Optional author override for this injector's contracts. "
+        "When absent, the platform attributes them to the injector's name.",
+    )

--- a/netexec/netexec/configuration/config_loader.py
+++ b/netexec/netexec/configuration/config_loader.py
@@ -26,6 +26,9 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_netexec"},
                 "injector_contracts": {"data": build_all_contracts()},
+                # Optional author override; None lets the platform attribute
+                # the contracts to the injector's name.
+                "injector_author": {"data": self.injector.author},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/netexec/netexec/configuration/config_loader.py
+++ b/netexec/netexec/configuration/config_loader.py
@@ -26,8 +26,6 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_netexec"},
                 "injector_contracts": {"data": build_all_contracts()},
-                # Source-declared publisher of this injector's contracts.
-                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/netexec/netexec/configuration/injector_config_override.py
+++ b/netexec/netexec/configuration/injector_config_override.py
@@ -20,3 +20,8 @@ class InjectorConfigOverride(ConfigLoaderCollector):
         description="Determines the verbosity of the logs. Options: debug, info, warn, or error.",
         default="info",
     )
+    author: str | None = Field(
+        default=None,
+        description="Optional author override for this injector's contracts. "
+        "When absent, the platform attributes them to the injector's name.",
+    )

--- a/nmap/nmap/configuration/config_loader.py
+++ b/nmap/nmap/configuration/config_loader.py
@@ -21,6 +21,9 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_nmap"},
                 "injector_contracts": {"data": NmapContracts.build_contract()},
+                # Optional author override; None lets the platform attribute
+                # the contracts to the injector's name.
+                "injector_author": {"data": self.injector.author},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/nmap/nmap/configuration/config_loader.py
+++ b/nmap/nmap/configuration/config_loader.py
@@ -21,8 +21,6 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_nmap"},
                 "injector_contracts": {"data": NmapContracts.build_contract()},
-                # Source-declared publisher of this injector's contracts.
-                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/nmap/nmap/configuration/injector_config_override.py
+++ b/nmap/nmap/configuration/injector_config_override.py
@@ -15,3 +15,8 @@ class InjectorConfigOverride(ConfigLoaderCollector):
         default="nmap/img/nmap.png",
         description="Path to the icon file",
     )
+    author: str | None = Field(
+        default=None,
+        description="Optional author override for this injector's contracts. "
+        "When absent, the platform attributes them to the injector's name.",
+    )

--- a/nmap/nmap/configuration/injector_config_override.py
+++ b/nmap/nmap/configuration/injector_config_override.py
@@ -16,7 +16,10 @@ class InjectorConfigOverride(ConfigLoaderCollector):
         description="Path to the icon file",
     )
     author: str | None = Field(
-        default=None,
-        description="Optional author override for this injector's contracts. "
-        "When absent, the platform attributes them to the injector's name.",
+        # Explicit author declaration (example of the override mechanism): the
+        # value matches the injector's name here, which is also what the
+        # platform would fall back to if the field were left unset.
+        default="Nmap",
+        description="Author attributed to this injector's contracts. "
+        "When unset, the platform attributes them to the injector's name.",
     )

--- a/nuclei/nuclei/configuration/config_loader.py
+++ b/nuclei/nuclei/configuration/config_loader.py
@@ -36,6 +36,9 @@ class ConfigLoader(SettingsLoader):
                 "injector_contracts": {
                     "data": NucleiContracts.build_static_contracts()
                 },
+                # Optional author override; None lets the platform attribute
+                # the contracts to the injector's name.
+                "injector_author": {"data": self.injector.author},
                 "injector_external_contracts_maintenance_schedule_seconds": {
                     "data": self.injector.external_contracts_maintenance_schedule_seconds
                 },

--- a/nuclei/nuclei/configuration/config_loader.py
+++ b/nuclei/nuclei/configuration/config_loader.py
@@ -36,8 +36,6 @@ class ConfigLoader(SettingsLoader):
                 "injector_contracts": {
                     "data": NucleiContracts.build_static_contracts()
                 },
-                # Source-declared publisher of this injector's contracts.
-                "injector_author": {"data": "Filigran"},
                 "injector_external_contracts_maintenance_schedule_seconds": {
                     "data": self.injector.external_contracts_maintenance_schedule_seconds
                 },

--- a/nuclei/nuclei/configuration/injector_config_override.py
+++ b/nuclei/nuclei/configuration/injector_config_override.py
@@ -15,6 +15,11 @@ class InjectorConfigOverride(ConfigLoaderCollector):
         default="nuclei/img/nuclei.png",
         description="Path to the icon file",
     )
+    author: str | None = Field(
+        default=None,
+        description="Optional author override for this injector's contracts. "
+        "When absent, the platform attributes them to the injector's name.",
+    )
     external_contracts_maintenance_schedule_seconds: int = Field(
         description="With every tick, trigger a maintenance of the external contracts (e.g. based on Nuclei templates)",
         default=86400,

--- a/nuclei/nuclei/configuration/injector_config_override.py
+++ b/nuclei/nuclei/configuration/injector_config_override.py
@@ -16,9 +16,12 @@ class InjectorConfigOverride(ConfigLoaderCollector):
         description="Path to the icon file",
     )
     author: str | None = Field(
-        default=None,
-        description="Optional author override for this injector's contracts. "
-        "When absent, the platform attributes them to the injector's name.",
+        # Explicit author declaration (example of the override mechanism): the
+        # value matches the injector's name here, which is also what the
+        # platform would fall back to if the field were left unset.
+        default="Nuclei",
+        description="Author attributed to this injector's contracts. "
+        "When unset, the platform attributes them to the injector's name.",
     )
     external_contracts_maintenance_schedule_seconds: int = Field(
         description="With every tick, trigger a maintenance of the external contracts (e.g. based on Nuclei templates)",

--- a/shodan/shodan/models/configs/config_loader.py
+++ b/shodan/shodan/models/configs/config_loader.py
@@ -35,8 +35,6 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_shodan"},
                 "injector_contracts": {"data": ShodanContracts().contracts()},
-                # Source-declared publisher of this injector's contracts.
-                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/shodan/shodan/models/configs/config_loader.py
+++ b/shodan/shodan/models/configs/config_loader.py
@@ -35,6 +35,9 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_shodan"},
                 "injector_contracts": {"data": ShodanContracts().contracts()},
+                # Optional author override; None lets the platform attribute
+                # the contracts to the injector's name.
+                "injector_author": {"data": self.injector.author},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/shodan/shodan/models/configs/injector_config_override.py
+++ b/shodan/shodan/models/configs/injector_config_override.py
@@ -15,6 +15,11 @@ class InjectorConfigOverride(ConfigLoaderCollector):
         default="shodan/img/icon-shodan.png",
         description="Path to the icon file",
     )
+    author: str | None = Field(
+        default=None,
+        description="Optional author override for this injector's contracts. "
+        "When absent, the platform attributes them to the injector's name.",
+    )
 
     def to_daemon_config(self) -> Configuration:
         return Configuration(

--- a/slack/slack_injector/configuration/config_loader.py
+++ b/slack/slack_injector/configuration/config_loader.py
@@ -23,6 +23,9 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": self.injector.type},
                 "injector_contracts": {"data": SlackContracts.build()},
+                # Optional author override; None lets the platform attribute
+                # the contracts to the injector's name.
+                "injector_author": {"data": self.injector.author},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/slack/slack_injector/configuration/config_loader.py
+++ b/slack/slack_injector/configuration/config_loader.py
@@ -23,8 +23,6 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": self.injector.type},
                 "injector_contracts": {"data": SlackContracts.build()},
-                # Source-declared publisher of this injector's contracts.
-                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/slack/slack_injector/configuration/injector_config_override.py
+++ b/slack/slack_injector/configuration/injector_config_override.py
@@ -22,3 +22,8 @@ class InjectorConfigOverride(ConfigLoaderCollector):
         description="Determines the verbosity of the logs. Options: debug, info, warn, or error.",
         default="info",
     )
+    author: str | None = Field(
+        default=None,
+        description="Optional author override for this injector's contracts. "
+        "When absent, the platform attributes them to the injector's name.",
+    )

--- a/stratus/stratus/configuration/config_loader.py
+++ b/stratus/stratus/configuration/config_loader.py
@@ -19,8 +19,6 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_stratus"},
                 "injector_contracts": {"data": build_all_contracts()},
-                # Source-declared publisher of this injector's contracts.
-                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/stratus/stratus/configuration/config_loader.py
+++ b/stratus/stratus/configuration/config_loader.py
@@ -19,6 +19,9 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": "openaev_stratus"},
                 "injector_contracts": {"data": build_all_contracts()},
+                # Optional author override; None lets the platform attribute
+                # the contracts to the injector's name.
+                "injector_author": {"data": self.injector.author},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/stratus/stratus/configuration/injector_config_override.py
+++ b/stratus/stratus/configuration/injector_config_override.py
@@ -14,3 +14,8 @@ class InjectorConfigOverride(ConfigLoaderCollector):
         default="stratus/img/icon-stratus.png",
         description="Path to the icon file",
     )
+    author: str | None = Field(
+        default=None,
+        description="Optional author override for this injector's contracts. "
+        "When absent, the platform attributes them to the injector's name.",
+    )

--- a/teams/teams/configuration/config_loader.py
+++ b/teams/teams/configuration/config_loader.py
@@ -22,6 +22,9 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": self.injector.type},
                 "injector_contracts": {"data": TeamsContracts.build()},
+                # Optional author override; None lets the platform attribute
+                # the contracts to the injector's name.
+                "injector_author": {"data": self.injector.author},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/teams/teams/configuration/config_loader.py
+++ b/teams/teams/configuration/config_loader.py
@@ -22,8 +22,6 @@ class ConfigLoader(SettingsLoader):
                 "injector_name": {"data": self.injector.name},
                 "injector_type": {"data": self.injector.type},
                 "injector_contracts": {"data": TeamsContracts.build()},
-                # Source-declared publisher of this injector's contracts.
-                "injector_author": {"data": "Filigran"},
                 "injector_log_level": {"data": self.injector.log_level},
                 "injector_icon_filepath": {"data": self.injector.icon_filepath},
             },

--- a/teams/teams/configuration/injector_config_override.py
+++ b/teams/teams/configuration/injector_config_override.py
@@ -23,3 +23,8 @@ class InjectorConfigOverride(ConfigLoaderCollector):
         description="Determines the verbosity of the logs. Options: debug, info, warn, or error.",
         default="info",
     )
+    author: str | None = Field(
+        default=None,
+        description="Optional author override for this injector's contracts. "
+        "When absent, the platform attributes them to the injector's name.",
+    )


### PR DESCRIPTION
### Proposed changes

* Remove the hardcoded `"injector_author": {"data": "Filigran"}` from every external
  injector `config_loader.py` (ai-redteam, aws, censys, email-m365, http-query, netexec,
  nmap, nuclei, shodan, slack, stratus, teams).
* With no declared author, the OpenAEV platform falls back to the injector's own name as
  the contract author organization, so arsenal items are attributed to "Nmap", "Nuclei",
  "NetExec", etc. instead of "Filigran".
* "Filigran" authorship stays reserved for the genuinely built-in in-platform injectors
  (SMTP email, media pressure, challenge, manual).
* Make the author overridable per deployment: every injector (including
  email-google-workspace) now has an optional `author` field on its
  `InjectorConfigOverride` (YAML `injector.author` / env `INJECTOR_AUTHOR`), forwarded as
  `injector_author` at registration. Default is `None`, which keeps the platform's
  name-based fallback.
* Declare explicit example authors on Nmap and Nuclei: their `author` field now defaults
  to "Nmap" / "Nuclei" as a reference example of the declaration mechanism. The values
  match what the name fallback would produce, so the attribution is identical - the
  point is to show injector maintainers how to declare an author explicitly.

### Testing Instructions

1. Start any injector from this repo (e.g. Nmap or Nuclei) against a local OpenAEV.
2. Open Threat Arsenal and check the author column of the contracts registered by the
   injector: it must show the injector's name (e.g. "Nmap"), not "Filigran".
3. Set `injector.author` (or `INJECTOR_AUTHOR`) in the injector config and restart it:
   the declared value wins over the name fallback and existing contracts are
   re-attributed on registration.
4. Nmap and Nuclei now declare their author explicitly by default ("Nmap" / "Nuclei"):
   starting them without any author configuration must attribute contracts exactly as
   before.

### Related issues

* Closes #373

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
