### PR TITLE
feat(ai-redteam): emit per-target execution traces for each AI target (#375)

### DIFF
--- a/ai-redteam/ai_redteam/openaev_ai_redteam.py
+++ b/ai-redteam/ai_redteam/openaev_ai_redteam.py
@@ -95,9 +95,11 @@ class OpenAEVAiRedTeam:
         logger.info(f"Invoking engine '{engine_key}' run() for inject {inject_id}...")
         results = []
         for target in targets:
+            target_start = time.time()
             result = engine.run(
                 content, target, marker, ctx={"inject_id": inject_id, "logger": logger}
             )
+            target_duration = int(time.time() - target_start)
             logger.info(
                 f"Engine '{engine_key}' finished for target "
                 f"'{self._target_label(target)}' (inject {inject_id}): "
@@ -109,18 +111,19 @@ class OpenAEVAiRedTeam:
             # completion callback stays global (aggregated summary in "Execution details"); this
             # target-scoped trace carries the AI target asset id so the platform shows it under
             # that target's execution timeline.
-            self._send_target_trace(inject_id, target, result, start)
+            self._send_target_trace(inject_id, target, result, target_duration)
 
         return self._aggregate_results(targets, results)
 
-    def _send_target_trace(self, inject_id, target, result, start: float) -> None:
+    def _send_target_trace(self, inject_id, target, result, duration: int) -> None:
         """Emit a target-scoped execution trace for one AI target.
 
         Only asset-backed targets (ai_target / asset-group modes) have a per-target result view,
         so inline/manual targets (no ``asset_id``) are skipped - their output already appears in the
         global completion trace. Uses the ``command_execution`` action (an intermediate EXECUTION
         trace) so it never triggers the terminal-completion handling reserved for the final
-        aggregated callback.
+        aggregated callback. ``duration`` is this target's own engine-run time (not the cumulative
+        inject elapsed time) so the per-target timeline entry reflects that target's run.
         """
         asset_id = getattr(target, "asset_id", None)
         if not asset_id:
@@ -132,7 +135,7 @@ class OpenAEVAiRedTeam:
                 data={
                     "execution_message": result.message,
                     "execution_status": result.status,
-                    "execution_duration": int(time.time() - start),
+                    "execution_duration": duration,
                     "execution_action": "command_execution",
                     "execution_context_identifiers": [asset_id],
                 },

--- a/ai-redteam/ai_redteam/openaev_ai_redteam.py
+++ b/ai-redteam/ai_redteam/openaev_ai_redteam.py
@@ -105,8 +105,47 @@ class OpenAEVAiRedTeam:
                 f"output_keys={sorted((result.outputs or {}).keys())}"
             )
             results.append(result)
+            # Per-target execution trace so the target's result view is not empty. The final
+            # completion callback stays global (aggregated summary in "Execution details"); this
+            # target-scoped trace carries the AI target asset id so the platform shows it under
+            # that target's execution timeline.
+            self._send_target_trace(inject_id, target, result, start)
 
         return self._aggregate_results(targets, results)
+
+    def _send_target_trace(self, inject_id, target, result, start: float) -> None:
+        """Emit a target-scoped execution trace for one AI target.
+
+        Only asset-backed targets (ai_target / asset-group modes) have a per-target result view,
+        so inline/manual targets (no ``asset_id``) are skipped - their output already appears in the
+        global completion trace. Uses the ``command_execution`` action (an intermediate EXECUTION
+        trace) so it never triggers the terminal-completion handling reserved for the final
+        aggregated callback.
+        """
+        asset_id = getattr(target, "asset_id", None)
+        if not asset_id:
+            return
+        logger = self.helper.injector_logger
+        try:
+            self.helper.api.inject.execution_callback(
+                inject_id=inject_id,
+                data={
+                    "execution_message": result.message,
+                    "execution_status": result.status,
+                    "execution_duration": int(time.time() - start),
+                    "execution_action": "command_execution",
+                    "execution_context_identifiers": [asset_id],
+                },
+            )
+            logger.info(
+                f"Per-target execution trace sent for inject {inject_id} "
+                f"(target '{self._target_label(target)}', asset {asset_id})"
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                f"Failed to send per-target execution trace for inject {inject_id} "
+                f"(target '{self._target_label(target)}', asset {asset_id}): {exc}"
+            )
 
     @staticmethod
     def _target_label(target) -> str:

--- a/ai-redteam/ai_redteam/openaev_ai_redteam.py
+++ b/ai-redteam/ai_redteam/openaev_ai_redteam.py
@@ -95,11 +95,14 @@ class OpenAEVAiRedTeam:
         logger.info(f"Invoking engine '{engine_key}' run() for inject {inject_id}...")
         results = []
         for target in targets:
-            target_start = time.time()
+            # Monotonic clock: this is a self-contained elapsed measurement, so it must not
+            # be affected by a wall-clock adjustment (e.g. NTP correction) mid-run, which could
+            # otherwise yield a negative or inconsistent per-target duration.
+            target_start = time.monotonic()
             result = engine.run(
                 content, target, marker, ctx={"inject_id": inject_id, "logger": logger}
             )
-            target_duration = int(time.time() - target_start)
+            target_duration = int(time.monotonic() - target_start)
             logger.info(
                 f"Engine '{engine_key}' finished for target "
                 f"'{self._target_label(target)}' (inject {inject_id}): "

--- a/ai-redteam/test/test_injector.py
+++ b/ai-redteam/test/test_injector.py
@@ -106,6 +106,10 @@ class OpenAEVAiRedTeamTest(TestCase):
         self.assertEqual(data["execution_action"], "command_execution")
         self.assertEqual(data["execution_status"], "SUCCESS")
         self.assertEqual(data["execution_message"], "[VULNERABLE] leaked marker")
+        # Duration is this target's own engine-run time, measured per target
+        # rather than derived from the inject-level start timestamp.
+        self.assertIsInstance(data["execution_duration"], int)
+        self.assertGreaterEqual(data["execution_duration"], 0)
 
     def test_ai_execution_skips_per_target_trace_for_manual_target(self):
         from ai_redteam.targets.target_resolver import TargetConfig

--- a/ai-redteam/test/test_injector.py
+++ b/ai-redteam/test/test_injector.py
@@ -1,6 +1,6 @@
 import importlib.util
 from unittest import TestCase, skipUnless
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from ai_redteam.engines.base import EngineResult
 
@@ -78,6 +78,55 @@ class OpenAEVAiRedTeamTest(TestCase):
         obj.process_message(_data())
         final = obj.helper.api.inject.execution_callback.call_args
         self.assertEqual(final.kwargs["data"]["execution_status"], "ERROR")
+
+    def test_ai_execution_emits_per_target_trace_for_asset_backed_target(self):
+        from ai_redteam.targets.target_resolver import TargetConfig
+
+        engine = MagicMock()
+        engine.run.return_value = EngineResult(
+            success=True,
+            message="[VULNERABLE] leaked marker",
+            outputs={"response": "reply"},
+            status="SUCCESS",
+        )
+        obj = self._injector(engine)
+        target = TargetConfig(name="CTEM Assistant", asset_id="asset-42")
+        with patch(
+            "ai_redteam.openaev_ai_redteam.resolve_targets", return_value=[target]
+        ):
+            obj.ai_execution(0.0, _data())
+
+        calls = obj.helper.api.inject.execution_callback.call_args_list
+        target_calls = [
+            c for c in calls if c.kwargs["data"].get("execution_context_identifiers")
+        ]
+        self.assertEqual(len(target_calls), 1)
+        data = target_calls[0].kwargs["data"]
+        self.assertEqual(data["execution_context_identifiers"], ["asset-42"])
+        self.assertEqual(data["execution_action"], "command_execution")
+        self.assertEqual(data["execution_status"], "SUCCESS")
+        self.assertEqual(data["execution_message"], "[VULNERABLE] leaked marker")
+
+    def test_ai_execution_skips_per_target_trace_for_manual_target(self):
+        from ai_redteam.targets.target_resolver import TargetConfig
+
+        engine = MagicMock()
+        engine.run.return_value = EngineResult(
+            success=False, message="defended", outputs={}, status="SUCCESS"
+        )
+        obj = self._injector(engine)
+        # Inline/manual target: no asset_id, so no per-target result view exists.
+        target = TargetConfig(endpoint="https://example.test", model="gpt")
+        with patch(
+            "ai_redteam.openaev_ai_redteam.resolve_targets", return_value=[target]
+        ):
+            obj.ai_execution(0.0, _data())
+
+        calls = obj.helper.api.inject.execution_callback.call_args_list
+        target_calls = [
+            c for c in calls if c.kwargs["data"].get("execution_context_identifiers")
+        ]
+        self.assertEqual(target_calls, [])
 
     def test_aggregate_keys_results_by_asset_id_to_avoid_collision(self):
         from ai_redteam.targets.target_resolver import TargetConfig


### PR DESCRIPTION
## Summary

- The AI Red Team injector only sent a single global aggregated execution callback, so each AI target's per-target result view showed "No traces on this target" while the global "Execution details" tab had the summary.
- After each target's engine run, emit an intermediate target-scoped execution trace carrying the target's asset id via `execution_context_identifiers`, so the platform shows it under that target's execution timeline.
- Each per-target trace reports that target's own engine-run duration (measured from a per-target start captured immediately before `engine.run`), not the cumulative inject elapsed time - so multi-target timelines are accurate.
- Inline / manual targets (no asset) are skipped - they have no per-target result view. The final aggregated completion callback stays global, so the "Execution details" tab is unchanged.

Closes #375

## Platform dependency

This relies on the platform accepting `execution_context_identifiers` on the injector execution callback (an agent-less trace scoped to one or more target assets). That change is shipped platform-side (openaev), so this PR is safe once the matching platform version is deployed; on older platforms the extra field is ignored and the trace simply stays global (no regression).

## Test plan

- [x] `pytest test/test_injector.py` - `test_ai_execution_emits_per_target_trace_for_asset_backed_target` (now also asserts the per-target duration) and `test_ai_execution_skips_per_target_trace_for_manual_target`; all 8 tests pass
- [x] `ruff check` and `ruff format --check` on changed files
- [ ] Manual: run an AI Red Team atomic test against an AI target asset and confirm the target's result view now shows an execution trace
