### PR TITLE
feat(injectors): emit per-target execution traces for scan injectors (#377)

### DIFF
--- a/injector_common/injector_common/traces.py
+++ b/injector_common/injector_common/traces.py
@@ -7,7 +7,7 @@ from pyoaev.helpers import OpenAEVInjectorHelper
 def send_per_target_traces(
     helper: OpenAEVInjectorHelper,
     inject_id: str,
-    ip_to_asset_id_map: Optional[Dict[str, str]],
+    ip_to_asset_id_map: Optional[Dict[str, Optional[str]]],
     *,
     label: str,
     start: float,
@@ -22,17 +22,18 @@ def send_per_target_traces(
     ``execution_context_identifiers`` so the platform lists it under that target's
     execution timeline.
 
-    Manual/inline targets have no asset id (they are absent from
-    ``ip_to_asset_id_map``) and are therefore skipped - their output already
-    appears in the global completion trace. The ``command_execution`` action keeps
-    these traces intermediate so they never trigger the terminal-completion
-    handling reserved for the final aggregated ``complete`` callback, which the
-    caller still sends globally.
+    Targets without an asset id are skipped - either because they are absent from
+    ``ip_to_asset_id_map`` (manual/inline targets) or because their mapped asset id
+    is missing/empty; their output already appears in the global completion trace.
+    The ``command_execution`` action keeps these traces intermediate so they never
+    trigger the terminal-completion handling reserved for the final aggregated
+    ``complete`` callback, which the caller still sends globally.
     """
     if not ip_to_asset_id_map:
         return
     logger = helper.injector_logger
     duration = int(time.time() - start)
+    sent = 0
     for target, asset_id in ip_to_asset_id_map.items():
         if not asset_id:
             continue
@@ -47,7 +48,10 @@ def send_per_target_traces(
                     "execution_context_identifiers": [asset_id],
                 },
             )
-            logger.info(
+            sent += 1
+            # Per-target detail stays at DEBUG: an asset group can resolve to
+            # hundreds of targets, so one INFO line each would flood the logs.
+            logger.debug(
                 f"Per-target execution trace sent for inject {inject_id} "
                 f"(target '{target}', asset {asset_id})"
             )
@@ -56,3 +60,5 @@ def send_per_target_traces(
                 f"Failed to send per-target execution trace for inject {inject_id} "
                 f"(target '{target}', asset {asset_id}): {exc}"
             )
+    if sent:
+        logger.info(f"Sent {sent} per-target execution trace(s) for inject {inject_id}")

--- a/injector_common/injector_common/traces.py
+++ b/injector_common/injector_common/traces.py
@@ -1,0 +1,58 @@
+import time
+from typing import Dict, Optional
+
+from pyoaev.helpers import OpenAEVInjectorHelper
+
+
+def send_per_target_traces(
+    helper: OpenAEVInjectorHelper,
+    inject_id: str,
+    ip_to_asset_id_map: Optional[Dict[str, str]],
+    *,
+    label: str,
+    start: float,
+    status: str = "INFO",
+) -> None:
+    """Emit one target-scoped execution trace per asset-backed target.
+
+    Batch network injectors (nmap, nuclei, netexec) run a single command over all
+    targets and only send a global aggregated callback, so each endpoint's result
+    view shows "No traces on this target". This emits an intermediate
+    ``command_execution`` trace per target carrying the target's asset id via
+    ``execution_context_identifiers`` so the platform lists it under that target's
+    execution timeline.
+
+    Manual/inline targets have no asset id (they are absent from
+    ``ip_to_asset_id_map``) and are therefore skipped - their output already
+    appears in the global completion trace. The ``command_execution`` action keeps
+    these traces intermediate so they never trigger the terminal-completion
+    handling reserved for the final aggregated ``complete`` callback, which the
+    caller still sends globally.
+    """
+    if not ip_to_asset_id_map:
+        return
+    logger = helper.injector_logger
+    duration = int(time.time() - start)
+    for target, asset_id in ip_to_asset_id_map.items():
+        if not asset_id:
+            continue
+        try:
+            helper.api.inject.execution_callback(
+                inject_id=inject_id,
+                data={
+                    "execution_message": f"{label} executed against target {target}",
+                    "execution_status": status,
+                    "execution_duration": duration,
+                    "execution_action": "command_execution",
+                    "execution_context_identifiers": [asset_id],
+                },
+            )
+            logger.info(
+                f"Per-target execution trace sent for inject {inject_id} "
+                f"(target '{target}', asset {asset_id})"
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                f"Failed to send per-target execution trace for inject {inject_id} "
+                f"(target '{target}', asset {asset_id}): {exc}"
+            )

--- a/injector_common/test/test_traces.py
+++ b/injector_common/test/test_traces.py
@@ -1,0 +1,78 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from injector_common.traces import send_per_target_traces
+
+
+class SendPerTargetTracesTest(TestCase):
+    def setUp(self):
+        self.helper = MagicMock()
+        self.helper.api = MagicMock()
+        self.helper.injector_logger = MagicMock()
+
+    def test_emits_one_trace_per_asset_backed_target(self):
+        send_per_target_traces(
+            self.helper,
+            "inject-1",
+            {"10.0.0.1": "asset-1", "10.0.0.2": "asset-2"},
+            label="nmap scan",
+            start=0.0,
+        )
+
+        calls = self.helper.api.inject.execution_callback.call_args_list
+        self.assertEqual(len(calls), 2)
+        identifiers = sorted(
+            c.kwargs["data"]["execution_context_identifiers"][0] for c in calls
+        )
+        self.assertEqual(identifiers, ["asset-1", "asset-2"])
+        for c in calls:
+            data = c.kwargs["data"]
+            self.assertEqual(c.kwargs["inject_id"], "inject-1")
+            self.assertEqual(data["execution_action"], "command_execution")
+            self.assertEqual(data["execution_status"], "INFO")
+            self.assertIn(
+                "nmap scan executed against target", data["execution_message"]
+            )
+
+    def test_skips_targets_without_asset_id(self):
+        send_per_target_traces(
+            self.helper,
+            "inject-1",
+            {"10.0.0.1": "asset-1", "manual-host": None},
+            label="nuclei scan",
+            start=0.0,
+        )
+
+        calls = self.helper.api.inject.execution_callback.call_args_list
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(
+            calls[0].kwargs["data"]["execution_context_identifiers"], ["asset-1"]
+        )
+
+    def test_noop_when_map_is_empty_or_none(self):
+        send_per_target_traces(
+            self.helper, "inject-1", {}, label="nmap scan", start=0.0
+        )
+        send_per_target_traces(
+            self.helper, "inject-1", None, label="nmap scan", start=0.0
+        )
+        self.helper.api.inject.execution_callback.assert_not_called()
+
+    def test_one_target_failure_does_not_stop_the_others(self):
+        # A callback failure for one target must be logged but must not prevent
+        # the remaining targets from getting their trace.
+        self.helper.api.inject.execution_callback.side_effect = [
+            RuntimeError("boom"),
+            None,
+        ]
+
+        send_per_target_traces(
+            self.helper,
+            "inject-1",
+            {"10.0.0.1": "asset-1", "10.0.0.2": "asset-2"},
+            label="NetExec",
+            start=0.0,
+        )
+
+        self.assertEqual(self.helper.api.inject.execution_callback.call_count, 2)
+        self.helper.injector_logger.error.assert_called_once()

--- a/injector_common/test/test_traces.py
+++ b/injector_common/test/test_traces.py
@@ -34,6 +34,15 @@ class SendPerTargetTracesTest(TestCase):
                 "nmap scan executed against target", data["execution_message"]
             )
 
+        # Per-target detail is logged at DEBUG (one line per asset); only a single
+        # INFO summary line is emitted so large batched scans do not flood the logs.
+        self.assertEqual(self.helper.injector_logger.debug.call_count, 2)
+        self.helper.injector_logger.info.assert_called_once()
+        self.assertIn(
+            "Sent 2 per-target execution trace(s) for inject inject-1",
+            self.helper.injector_logger.info.call_args.args[0],
+        )
+
     def test_skips_targets_without_asset_id(self):
         send_per_target_traces(
             self.helper,
@@ -57,6 +66,8 @@ class SendPerTargetTracesTest(TestCase):
             self.helper, "inject-1", None, label="nmap scan", start=0.0
         )
         self.helper.api.inject.execution_callback.assert_not_called()
+        # Nothing sent -> no summary line either.
+        self.helper.injector_logger.info.assert_not_called()
 
     def test_one_target_failure_does_not_stop_the_others(self):
         # A callback failure for one target must be logged but must not prevent

--- a/netexec/netexec/openaev_netexec.py
+++ b/netexec/netexec/openaev_netexec.py
@@ -15,6 +15,7 @@ from injector_common.constants import TARGET_PROPERTY_SELECTOR_KEY, TARGET_SELEC
 from injector_common.data_helpers import DataHelpers
 from injector_common.dump_config import intercept_dump_argument
 from injector_common.targets import TargetProperty, Targets
+from injector_common.traces import send_per_target_traces
 from netexec.configuration.config_loader import ConfigLoader
 from netexec.contracts import parse_contract_id
 from netexec.helpers.netexec_command_builder import (
@@ -157,6 +158,16 @@ class OpenAEVNetExecInjector:
         self.helper.api.inject.execution_callback(
             inject_id=inject_id,
             data=callback_data,
+        )
+
+        # Per-target traces so each asset-backed endpoint's result view shows the
+        # run reached it; the batched run only sends a global callback otherwise.
+        send_per_target_traces(
+            self.helper,
+            inject_id,
+            target_results.ip_to_asset_id_map,
+            label="NetExec",
+            start=start,
         )
 
         output_file = parsed_data.get("output_file") if parsed_data else None

--- a/netexec/test/signatures/test_netexec_signature_lifecycle.py
+++ b/netexec/test/signatures/test_netexec_signature_lifecycle.py
@@ -8,6 +8,7 @@ pyoaev is mocked by test/conftest.py — SignatureManager and build_network_conf
 are both MagicMocks in this context, which lets us assert on their call signatures.
 """
 
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -202,6 +203,46 @@ class SignatureLifecycleTest(TestCase):
         self.mock_sm.build_execution_signatures.assert_called_once_with(
             config=["cfg-1", "cfg-2"]
         )
+
+    # -- Scenario: Each asset-backed target gets its own execution trace --
+
+    def test_process_message_emits_per_target_traces_for_asset_targets(self):
+        """
+        Given an inject targeting two asset-backed endpoints
+        When process_message runs the batched NetExec command
+        Then a target-scoped execution trace is emitted per asset id, so each
+        endpoint's result view shows the run reached it.
+        """
+        injector = self._make_injector()
+        data, _ = _build_data(["10.0.0.1", "10.0.0.2"])
+        extraction = SimpleNamespace(
+            targets=["10.0.0.1", "10.0.0.2"],
+            ip_to_asset_id_map={"10.0.0.1": "asset-1", "10.0.0.2": "asset-2"},
+        )
+
+        with patch(
+            "netexec.openaev_netexec.build_network_configs",
+            return_value=["cfg-1", "cfg-2"],
+        ), patch(
+            "netexec.openaev_netexec.Targets.extract_targets",
+            return_value=extraction,
+        ), patch(
+            "netexec.openaev_netexec.Targets.extract_target_meta",
+            return_value=[],
+        ):
+            self._run_process_message(injector, data, returncode=0)
+
+        calls = injector.helper.api.inject.execution_callback.call_args_list
+        target_calls = [
+            c for c in calls if c.kwargs["data"].get("execution_context_identifiers")
+        ]
+        self.assertEqual(len(target_calls), 2)
+        identifiers = sorted(
+            c.kwargs["data"]["execution_context_identifiers"][0] for c in target_calls
+        )
+        self.assertEqual(identifiers, ["asset-1", "asset-2"])
+        for c in target_calls:
+            self.assertEqual(c.kwargs["data"]["execution_action"], "command_execution")
 
 
 class NetexecSignatureTypesTest(TestCase):

--- a/nmap/nmap/openaev_nmap.py
+++ b/nmap/nmap/openaev_nmap.py
@@ -12,6 +12,7 @@ from pyoaev.signatures.models import (
 
 from injector_common.dump_config import intercept_dump_argument
 from injector_common.targets import Targets
+from injector_common.traces import send_per_target_traces
 from nmap.configuration.config_loader import ConfigLoader
 from nmap.helpers.nmap_command_builder import NmapCommandBuilder
 from nmap.helpers.nmap_output_parser import NmapOutputParser
@@ -56,6 +57,16 @@ class OpenAEVNmap:
         self.helper.api.inject.execution_callback(
             inject_id=msg_data.inject_id,
             data=callback_data,
+        )
+
+        # Per-target traces so each asset-backed endpoint's result view shows the
+        # scan reached it; the batched scan only sends a global callback otherwise.
+        send_per_target_traces(
+            self.helper,
+            msg_data.inject_id,
+            msg_data.target_results.ip_to_asset_id_map,
+            label="nmap scan",
+            start=start,
         )
 
         nmap_result = subprocess.run(nmap_args, check=True, capture_output=True)

--- a/nmap/test/test_openaev_nmap.py
+++ b/nmap/test/test_openaev_nmap.py
@@ -38,6 +38,9 @@ class TestOpenAEVNmap(unittest.TestCase):
 
         start = 1
         message_data = MagicMock()
+        # No asset-backed targets -> the per-target trace helper is a no-op, so the
+        # last execution_callback stays the global command_execution trace below.
+        message_data.target_results.ip_to_asset_id_map = {}
 
         nmap_output = injector.nmap_execution(start, message_data)
 
@@ -67,6 +70,49 @@ class TestOpenAEVNmap(unittest.TestCase):
             message_data.target_results,
         )
         self.assertEqual(nmap_output, m_xmlparse.return_value)
+
+    @patch.object(module.NmapOutputParser, "xmlparse")
+    @patch.object(module.subprocess, "run")
+    @patch.object(module.Targets, "build_execution_message")
+    @patch.object(module.NmapCommandBuilder, "build_args")
+    def test_openaev_nmap_execution_emits_per_target_traces(
+        self,
+        m_build_args,
+        m_build_execution_message,
+        m_subprocess_run,
+        m_xmlparse,
+        m_configloader,
+        m_helper,
+        m_msgdata,
+        _,
+    ):
+        m_helper.return_value.api = MagicMock()
+        m_helper.return_value.injector_logger = MagicMock()
+        injector = module.OpenAEVNmap()
+
+        message_data = MagicMock()
+        message_data.inject_id = "inject-id"
+        # Two asset-backed targets and one manual target (no asset id): only the
+        # asset-backed ones must get a target-scoped trace.
+        message_data.target_results.ip_to_asset_id_map = {
+            "10.0.0.1": "asset-1",
+            "10.0.0.2": "asset-2",
+        }
+
+        injector.nmap_execution(1, message_data)
+
+        calls = m_helper.return_value.api.inject.execution_callback.call_args_list
+        target_calls = [
+            c for c in calls if c.kwargs["data"].get("execution_context_identifiers")
+        ]
+        self.assertEqual(len(target_calls), 2)
+        identifiers = sorted(
+            c.kwargs["data"]["execution_context_identifiers"][0] for c in target_calls
+        )
+        self.assertEqual(identifiers, ["asset-1", "asset-2"])
+        for c in target_calls:
+            self.assertEqual(c.kwargs["data"]["execution_action"], "command_execution")
+            self.assertEqual(c.kwargs["data"]["execution_status"], "INFO")
 
     @patch.object(module.OpenAEVNmap, "nmap_execution")
     @patch.object(module, "ExecutionDetails")

--- a/nuclei/nuclei/openaev_nuclei.py
+++ b/nuclei/nuclei/openaev_nuclei.py
@@ -13,6 +13,7 @@ from pyoaev.signatures.models import ExecutionDetails
 
 from injector_common.dump_config import intercept_dump_argument
 from injector_common.targets import Targets
+from injector_common.traces import send_per_target_traces
 from nuclei.configuration.config_loader import ConfigLoader
 from nuclei.helpers.nuclei_command_builder import NucleiCommandBuilder
 from nuclei.helpers.nuclei_output_parser import NucleiOutputParser
@@ -71,6 +72,16 @@ class OpenAEVNuclei:
         self.helper.api.inject.execution_callback(
             inject_id=msg_data.inject_id,
             data=callback_data,
+        )
+
+        # Per-target traces so each asset-backed endpoint's result view shows the
+        # scan reached it; the batched scan only sends a global callback otherwise.
+        send_per_target_traces(
+            self.helper,
+            msg_data.inject_id,
+            msg_data.target_results.ip_to_asset_id_map,
+            label="nuclei scan",
+            start=start,
         )
 
         input_data = ("\n".join(targets) + "\n").encode("utf-8")

--- a/nuclei/test/test_openaev_nuclei.py
+++ b/nuclei/test/test_openaev_nuclei.py
@@ -51,6 +51,9 @@ class TestOpenAEVNuclei(unittest.TestCase):
         start = 1
         message_data = MagicMock()
         message_data.get_targets.return_value = ["1.1.1.1"]
+        # No asset-backed targets -> the per-target trace helper is a no-op, so the
+        # single execution_callback stays the global command_execution trace below.
+        message_data.target_results.ip_to_asset_id_map = {}
         m_builder.return_value.build.return_value = ["nuclei", "-jsonl"]
 
         nuclei_output = injector.nuclei_execution(start, message_data)
@@ -83,6 +86,47 @@ class TestOpenAEVNuclei(unittest.TestCase):
             message_data.target_results.ip_to_asset_id_map,
         )
         self.assertEqual(nuclei_output, m_parser.return_value.parse.return_value)
+
+    @patch.object(module.Targets, "build_execution_message")
+    @patch.object(module, "NucleiCommandBuilder")
+    def test_openaev_nuclei_execution_emits_per_target_traces(
+        self,
+        m_builder,
+        m_build_execution_message,
+        m_configloader,
+        m_confighelper,
+        m_helper,
+        m_nucleiprocess,
+        m_parser,
+        m_msgdata,
+        _,
+    ):
+        m_helper.return_value.api = MagicMock()
+        m_helper.return_value.injector_logger = MagicMock()
+        injector = module.OpenAEVNuclei()
+
+        message_data = MagicMock()
+        message_data.inject_id = "inject-id"
+        message_data.get_targets.return_value = ["10.0.0.1", "10.0.0.2"]
+        message_data.target_results.ip_to_asset_id_map = {
+            "10.0.0.1": "asset-1",
+            "10.0.0.2": "asset-2",
+        }
+        m_builder.return_value.build.return_value = ["nuclei", "-jsonl"]
+
+        injector.nuclei_execution(1, message_data)
+
+        calls = m_helper.return_value.api.inject.execution_callback.call_args_list
+        target_calls = [
+            c for c in calls if c.kwargs["data"].get("execution_context_identifiers")
+        ]
+        self.assertEqual(len(target_calls), 2)
+        identifiers = sorted(
+            c.kwargs["data"]["execution_context_identifiers"][0] for c in target_calls
+        )
+        self.assertEqual(identifiers, ["asset-1", "asset-2"])
+        for c in target_calls:
+            self.assertEqual(c.kwargs["data"]["execution_action"], "command_execution")
 
     @patch.object(module.OpenAEVNuclei, "nuclei_execution")
     @patch.object(module, "ExecutionDetails")


### PR DESCRIPTION
## Summary

- The scan injectors (nmap, nuclei, netexec) ran a single batched command over all resolved targets and only sent a global aggregated execution callback, so each endpoint's result view showed "No traces on this target".
- Each of the three injectors now emits an intermediate, target-scoped execution trace per asset-backed target. The trace carries the target's asset id via `execution_context_identifiers`, so the platform lists it under that target's execution timeline.
- Logic is centralized in a new shared helper `injector_common.traces.send_per_target_traces` so the three injectors stay in lockstep. It is called right after the existing global `command_execution` trace, before the batched command runs.

## Behavior

- Targets without an asset id are skipped - either because they are absent from `ip_to_asset_id_map` (manual/inline targets) or because their mapped asset id is missing/empty; their output already appears in the global completion trace.
- The traces use the `command_execution` action so they stay intermediate and never trigger the terminal-completion handling reserved for the final aggregated `complete` callback, which stays global.
- A per-target callback failure is logged but never blocks the remaining targets or the terminal callback.
- Per-target detail is logged at DEBUG (one line per asset) with a single INFO summary line reporting the count, so large asset-group scans do not flood the logs.

## Out of scope

- http-query performs a single HTTP request against one URL and has no per-asset target concept, so it is intentionally not changed.
- This is separate from the AI Red Team per-target trace change.

## Test plan

- [x] `injector_common`: unit tests for `send_per_target_traces` (per-target emission, skip-without-asset-id, empty/None no-op, one failure does not stop others, and the DEBUG-per-target / single-INFO-summary logging contract).
- [x] nmap: new test asserting per-target traces for asset-backed targets; existing execution test updated for the empty-map no-op path.
- [x] nuclei: new test asserting per-target traces; existing execution test updated.
- [x] netexec: new lifecycle test asserting per-target traces for asset targets.
- [x] black, isort (`--profile black --line-length 88`), flake8 clean.

## Review follow-up (960af69)

Addressed the review pass on the shared helper: the asset id map values are now typed `Optional[str]` (the helper guards falsy asset ids and the source `asset.get("asset_id")` can yield `None`); the per-target success log is demoted to DEBUG with a single INFO summary line (mirroring the ai-redteam intermediate-trace logging); and the docstring now states that both absent and missing/empty asset ids are skipped. New assertions lock in the logging contract.

Closes #377
