### PR TITLE
feat(nuclei): register Nuclei as a security platform for vulnerability verdicts (#381)

### DIFF
--- a/nuclei/nuclei/openaev_nuclei.py
+++ b/nuclei/nuclei/openaev_nuclei.py
@@ -21,6 +21,20 @@ from nuclei.helpers.nuclei_process import NucleiProcess
 from nuclei.models.data import MessageData
 from nuclei.nuclei_contracts.external_contracts import ExternalContractsScheduler
 
+# Security platform identity declared by this injector. Nuclei performs the
+# vulnerability assessment itself, so the platform can attribute VULNERABILITY
+# expectation verdicts to a real "Nuclei" security platform entry (logo and
+# all), the same way detection/prevention verdicts are attributed to EDR/SIEM
+# platforms instead of a generic manager.
+SECURITY_PLATFORM_NAME = "Nuclei"
+SECURITY_PLATFORM_TYPE = "VULNERABILITY_SCANNER"
+SECURITY_PLATFORM_DESCRIPTION = (
+    "Nuclei is a fast, template-based vulnerability scanner. This platform "
+    "entry is managed by the Nuclei injector and receives the vulnerability "
+    "verdicts of its scans."
+)
+SECURITY_PLATFORM_LOGO_PATH = "nuclei/img/nuclei.jpg"
+
 
 class OpenAEVNuclei:
     def __init__(self):
@@ -245,7 +259,45 @@ class OpenAEVNuclei:
         except (FileNotFoundError, subprocess.CalledProcessError):
             return False
 
+    def _register_security_platform(self) -> None:
+        """Declare Nuclei as a security platform (best-effort).
+
+        The upsert is keyed on the injector type (``asset_external_reference``)
+        so every Nuclei injector deployment shares one platform entry, and so
+        the backend can attribute vulnerability verdicts to it by resolving the
+        inject's injector type. Registration is best-effort: backends that do
+        not support the VULNERABILITY_SCANNER platform type yet reject the
+        call, and the injector must keep working exactly as before.
+        """
+        try:
+            with open(SECURITY_PLATFORM_LOGO_PATH, "rb") as logo:
+                document = self.helper.api.document.upsert(
+                    document={}, file=("nuclei.jpg", logo, "image/jpeg")
+                )
+            self.helper.api.security_platform.upsert(
+                {
+                    "asset_name": SECURITY_PLATFORM_NAME,
+                    "asset_external_reference": self.config.get_conf(
+                        "injector_type", default="openaev_nuclei"
+                    ),
+                    "asset_description": SECURITY_PLATFORM_DESCRIPTION,
+                    "security_platform_type": SECURITY_PLATFORM_TYPE,
+                    "security_platform_logo_light": document.get("document_id"),
+                    "security_platform_logo_dark": document.get("document_id"),
+                }
+            )
+            self.helper.injector_logger.info(
+                "Registered Nuclei as a security platform (vulnerability scanner)"
+            )
+        except Exception as err:
+            self.helper.injector_logger.warning(
+                "Could not register Nuclei as a security platform (requires an "
+                "OpenAEV version supporting the VULNERABILITY_SCANNER platform "
+                "type): " + str(err)
+            )
+
     def start(self):
+        self._register_security_platform()
         self.helper.listen(message_callback=self.process_message)
         ExternalContractsScheduler(
             self.helper.api,

--- a/nuclei/test/test_openaev_nuclei.py
+++ b/nuclei/test/test_openaev_nuclei.py
@@ -351,6 +351,68 @@ class TestOpenAEVNuclei(unittest.TestCase):
             message_callback=injector.process_message
         )
 
+    def test_openaev_nuclei_start_registers_security_platform(
+        self,
+        m_configloader,
+        m_confighelper,
+        m_helper,
+        m_nucleiprocess,
+        m_parser,
+        m_msgdata,
+        _,
+    ):
+        m_helper.return_value.api = MagicMock()
+        m_helper.return_value.injector_logger = MagicMock()
+        m_confighelper.from_configuration_object.return_value.get_conf.return_value = (
+            "openaev_nuclei"
+        )
+        injector = module.OpenAEVNuclei()
+        injector.helper.api.document.upsert.return_value = {"document_id": "doc-1"}
+
+        with patch.object(module, "ExternalContractsScheduler"):
+            injector.start()
+
+        injector.helper.api.document.upsert.assert_called_once_with(
+            document={}, file=("nuclei.jpg", ANY, "image/jpeg")
+        )
+        injector.helper.api.security_platform.upsert.assert_called_once_with(
+            {
+                "asset_name": "Nuclei",
+                "asset_external_reference": "openaev_nuclei",
+                "asset_description": module.SECURITY_PLATFORM_DESCRIPTION,
+                "security_platform_type": "VULNERABILITY_SCANNER",
+                "security_platform_logo_light": "doc-1",
+                "security_platform_logo_dark": "doc-1",
+            }
+        )
+
+    def test_openaev_nuclei_security_platform_registration_is_best_effort(
+        self,
+        m_configloader,
+        m_confighelper,
+        m_helper,
+        m_nucleiprocess,
+        m_parser,
+        m_msgdata,
+        _,
+    ):
+        # A backend without VULNERABILITY_SCANNER support rejects the upsert:
+        # the injector must log a warning and keep starting normally.
+        m_helper.return_value.api = MagicMock()
+        m_helper.return_value.injector_logger = MagicMock()
+        injector = module.OpenAEVNuclei()
+        injector.helper.api.security_platform.upsert.side_effect = ValueError(
+            "unknown security_platform_type"
+        )
+
+        with patch.object(module, "ExternalContractsScheduler"):
+            injector.start()
+
+        injector.helper.injector_logger.warning.assert_called()
+        injector.helper.listen.assert_called_with(
+            message_callback=injector.process_message
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- At startup, the Nuclei injector now registers/upserts a "Nuclei" security platform entry (type VULNERABILITY_SCANNER) with the injector logo, keyed on the injector type (openaev_nuclei) via asset_external_reference.
- This gives the backend a stable key to attribute vulnerability expectation verdicts to Nuclei itself (a real per-platform row, like Microsoft Defender for detection/prevention) instead of the generic "Expectations Vulnerability Manager" collector. The backend-side attribution is handled separately in the platform repository.
- Registration is strictly best-effort: on OpenAEV versions that do not support the VULNERABILITY_SCANNER platform type yet, the upsert is rejected, a warning is logged, and the injector starts and scans exactly as before.

## Test plan

- [x] Unit test: start() uploads the logo document and upserts the security platform with the expected payload
- [x] Unit test: registration failure (older backend) logs a warning and does not prevent the injector from listening
- [x] Full nuclei test suite passes (32 tests)
- [x] black / isort / ruff clean

Closes #381
