### PR TITLE
feat(netexec): emit file findings from spider_plus share spidering (#390)

### DIFF
--- a/netexec/netexec/contracts/contract_outputs.py
+++ b/netexec/netexec/contracts/contract_outputs.py
@@ -10,6 +10,7 @@ from netexec.contracts.output_registry import (
     COMPUTER,
     CREDENTIALS,
     DELEGATION,
+    FILE,
     GROUP,
     KERBEROASTABLE,
     PASSWORD_POLICY,
@@ -51,6 +52,14 @@ _USERNAME_OUTPUT = ContractOutputElement(
 _SHARE_OUTPUT = ContractOutputElement(
     type=ContractOutputType.Share,
     field="shares",
+    isMultiple=True,
+    isFindingCompatible=True,
+    labels=["netexec"],
+)
+
+_FILE_OUTPUT = ContractOutputElement(
+    type=ContractOutputType.File,
+    field="files",
     isMultiple=True,
     isFindingCompatible=True,
     labels=["netexec"],
@@ -149,6 +158,7 @@ _TYPE_TO_ELEMENT = {
     CREDENTIALS: _CREDENTIALS_OUTPUT,
     USERNAME: _USERNAME_OUTPUT,
     SHARE: _SHARE_OUTPUT,
+    FILE: _FILE_OUTPUT,
     ADMIN_USERNAME: _ADMIN_USERNAME_OUTPUT,
     GROUP: _GROUP_OUTPUT,
     COMPUTER: _COMPUTER_OUTPUT,

--- a/netexec/netexec/contracts/output_registry.py
+++ b/netexec/netexec/contracts/output_registry.py
@@ -17,6 +17,7 @@ TEXT = "text"
 CREDENTIALS = "credentials"
 USERNAME = "username"
 SHARE = "share"
+FILE = "file"
 ADMIN_USERNAME = "admin_username"
 GROUP = "group"
 COMPUTER = "computer"
@@ -155,8 +156,9 @@ _MODULE_OUTPUTS = {
     "uac": {TEXT},
     "wcc": {TEXT},
     "recent_files": {TEXT},
-    # File spider
-    "spider_plus": {TEXT},
+    # File spider: stdout only carries stats; the per-file list is written to a
+    # JSON metadata file, parsed separately into `file` findings.
+    "spider_plus": {TEXT, FILE},
     # Actions (execute something, limited stdout findings)
     "add_computer": {TEXT},
     "empire_exec": {TEXT},

--- a/netexec/netexec/helpers/netexec_command_builder.py
+++ b/netexec/netexec/helpers/netexec_command_builder.py
@@ -9,6 +9,11 @@ from netexec.modules_registry import get_module_by_safe_key
 # The command builder auto-generates a temp file path for these.
 OPTIONS_REQUIRING_OUTPUT_FILE = {"asreproast", "kerberoasting"}
 
+# Modules whose per-target findings are written to a JSON metadata folder rather
+# than to stdout. The builder forces a controlled output folder so the injector
+# knows where to read the metadata back from.
+SPIDER_PLUS_MODULE = "spider_plus"
+
 
 def build_command(
     protocol: str,
@@ -167,6 +172,17 @@ def extract_data_module(content: dict, protocol: str, safe_key: str) -> dict | N
     module_options_extra = content.get("module_options")
     if module_options_extra:
         module_opts.append(str(module_options_extra))
+
+    # spider_plus writes the file list to a JSON metadata folder, not stdout.
+    # Force a unique output folder we control (overriding any user-supplied one)
+    # so the injector can read the metadata back and emit `file` findings.
+    if module_name == SPIDER_PLUS_MODULE:
+        module_opts = [
+            opt for opt in module_opts if not opt.startswith("OUTPUT_FOLDER=")
+        ]
+        output_dir = f"/tmp/nxc_spider_plus_{uuid.uuid4().hex[:8]}"
+        module_opts.append(f"OUTPUT_FOLDER={output_dir}")
+        data["spider_output_dir"] = output_dir
 
     if module_opts:
         extra_args.extend(["-o"] + module_opts)

--- a/netexec/netexec/helpers/spider_plus_parser.py
+++ b/netexec/netexec/helpers/spider_plus_parser.py
@@ -1,0 +1,95 @@
+"""Parser for the NetExec ``spider_plus`` module metadata.
+
+Unlike every other NetExec output, ``spider_plus`` does not print the files it
+finds on stdout -- stdout only carries aggregate stats. The per-file list is
+written to a JSON metadata file per target (``<ip>.json``) in the module's
+output folder. This helper reads that folder and turns each file into a
+structured ``file`` finding.
+
+Metadata shape (one JSON per target)::
+
+    {
+      "SYSVOL": {
+        "north.sevenkingdoms.local/scripts/secret.ps1": {
+          "atime_epoch": "...", "ctime_epoch": "...",
+          "mtime_epoch": "...", "size": "869 B"
+        }
+      }
+    }
+
+The top-level key is the SMB share; the nested key is the file path relative to
+that share. The finding keeps ``file_name`` (basename) separate from ``path``
+(directory) and ``share`` so the platform can render the basename while still
+carrying the full location -- and so a share-hosted file links back to its
+``share`` finding.
+"""
+
+import json
+import os
+
+
+def _split_path(relative_path: str) -> tuple[str, str]:
+    """Return (directory, file_name) for a share-relative path.
+
+    ``north.sevenkingdoms.local/scripts/secret.ps1`` -> ("north.sevenkingdoms.local/scripts", "secret.ps1").
+    A top-level file yields an empty directory.
+    """
+    normalized = relative_path.replace("\\", "/").strip("/")
+    if "/" not in normalized:
+        return "", normalized
+    directory, _, file_name = normalized.rpartition("/")
+    return directory, file_name
+
+
+def extract_files_from_metadata(
+    spider_json: dict,
+    ip: str,
+    ip_to_asset_id_map: dict,
+) -> list[dict]:
+    """Flatten a single target's spider_plus metadata into file findings."""
+    results: list[dict] = []
+    asset_id = ip_to_asset_id_map.get(ip, "")
+    for share, files in (spider_json or {}).items():
+        if not isinstance(files, dict):
+            continue
+        for relative_path in files:
+            directory, file_name = _split_path(str(relative_path))
+            if not file_name:
+                continue
+            finding: dict = {
+                "file_name": file_name,
+                "path": directory,
+                "share": share,
+                "host": ip,
+            }
+            if asset_id:
+                finding["asset_id"] = asset_id
+            results.append(finding)
+    return results
+
+
+def parse_spider_output_dir(
+    output_dir: str,
+    ip_to_asset_id_map: dict,
+) -> list[dict]:
+    """Read every ``<ip>.json`` in *output_dir* and return all file findings.
+
+    The target IP is recovered from the JSON file name (netexec writes one file
+    per target named ``<ip>.json``). Missing or malformed files are skipped --
+    a spider run that reached no readable share simply yields no findings.
+    """
+    results: list[dict] = []
+    if not output_dir or not os.path.isdir(output_dir):
+        return results
+    for entry in sorted(os.listdir(output_dir)):
+        if not entry.endswith(".json"):
+            continue
+        ip = entry[: -len(".json")]
+        full_path = os.path.join(output_dir, entry)
+        try:
+            with open(full_path, "r", encoding="utf-8", errors="replace") as f:
+                spider_json = json.load(f)
+        except (OSError, ValueError):
+            continue
+        results.extend(extract_files_from_metadata(spider_json, ip, ip_to_asset_id_map))
+    return results

--- a/netexec/netexec/openaev_netexec.py
+++ b/netexec/netexec/openaev_netexec.py
@@ -4,11 +4,6 @@ import shutil
 import time
 from importlib.resources import files
 
-from injector_common.constants import TARGET_PROPERTY_SELECTOR_KEY, TARGET_SELECTOR_KEY
-from injector_common.data_helpers import DataHelpers
-from injector_common.dump_config import intercept_dump_argument
-from injector_common.targets import TargetProperty, Targets
-from injector_common.traces import send_per_target_traces
 from pyoaev.helpers import OpenAEVConfigHelper, OpenAEVInjectorHelper
 from pyoaev.signatures import SignatureManager
 from pyoaev.signatures.models import (
@@ -17,6 +12,11 @@ from pyoaev.signatures.models import (
     build_network_configs,
 )
 
+from injector_common.constants import TARGET_PROPERTY_SELECTOR_KEY, TARGET_SELECTOR_KEY
+from injector_common.data_helpers import DataHelpers
+from injector_common.dump_config import intercept_dump_argument
+from injector_common.targets import TargetProperty, Targets
+from injector_common.traces import send_per_target_traces
 from netexec.configuration.config_loader import ConfigLoader
 from netexec.contracts import parse_contract_id
 from netexec.helpers.netexec_command_builder import (

--- a/netexec/netexec/openaev_netexec.py
+++ b/netexec/netexec/openaev_netexec.py
@@ -1,8 +1,14 @@
 import json
 import os
+import shutil
 import time
 from importlib.resources import files
 
+from injector_common.constants import TARGET_PROPERTY_SELECTOR_KEY, TARGET_SELECTOR_KEY
+from injector_common.data_helpers import DataHelpers
+from injector_common.dump_config import intercept_dump_argument
+from injector_common.targets import TargetProperty, Targets
+from injector_common.traces import send_per_target_traces
 from pyoaev.helpers import OpenAEVConfigHelper, OpenAEVInjectorHelper
 from pyoaev.signatures import SignatureManager
 from pyoaev.signatures.models import (
@@ -11,11 +17,6 @@ from pyoaev.signatures.models import (
     build_network_configs,
 )
 
-from injector_common.constants import TARGET_PROPERTY_SELECTOR_KEY, TARGET_SELECTOR_KEY
-from injector_common.data_helpers import DataHelpers
-from injector_common.dump_config import intercept_dump_argument
-from injector_common.targets import TargetProperty, Targets
-from injector_common.traces import send_per_target_traces
 from netexec.configuration.config_loader import ConfigLoader
 from netexec.contracts import parse_contract_id
 from netexec.helpers.netexec_command_builder import (
@@ -27,6 +28,7 @@ from netexec.helpers.netexec_command_builder import (
 )
 from netexec.helpers.netexec_output_parser import NetExecOutputParser
 from netexec.helpers.netexec_process import execute_netexec
+from netexec.helpers.spider_plus_parser import parse_spider_output_dir
 
 _SENSITIVE_KEYS = {"password", "hash", "key_file", "username", "domain"}
 
@@ -171,6 +173,10 @@ class OpenAEVNetExecInjector:
         )
 
         output_file = parsed_data.get("output_file") if parsed_data else None
+        spider_output_dir = (
+            parsed_data.get("spider_output_dir") if parsed_data else None
+        )
+        spider_files: list[dict] = []
         execution_details, execution_signatures = self._pre_execution_compile(targets)
         try:
             stdout, stderr, returncode = execute_netexec(cmd)
@@ -188,6 +194,13 @@ class OpenAEVNetExecInjector:
                     self.helper.injector_logger.error(
                         f"Unable to execute NetExec due to missing file: {err}"
                     )
+
+            # spider_plus writes its file list to a JSON metadata folder, not
+            # stdout. Read it into `file` findings before the folder is cleaned.
+            if spider_output_dir:
+                spider_files = parse_spider_output_dir(
+                    spider_output_dir, target_results.ip_to_asset_id_map
+                )
         except Exception as err:
             self.helper.injector_logger.error(f"Unable to execute NetExec: {err}")
         finally:
@@ -196,6 +209,8 @@ class OpenAEVNetExecInjector:
                     os.remove(output_file)
                 except OSError:
                     pass
+            if spider_output_dir:
+                shutil.rmtree(spider_output_dir, ignore_errors=True)
 
         parse_result = self.parser.parse(
             stdout,
@@ -203,6 +218,12 @@ class OpenAEVNetExecInjector:
             family=contract_family,
             identifier=contract_identifier,
         )
+
+        # File findings come from the spider_plus JSON metadata, not stdout, so
+        # merge them into the structured outputs after the stdout parse.
+        if spider_files:
+            parse_result["outputs"]["files"] = spider_files
+            parse_result["message"] += f", {len(spider_files)} files"
         return {
             "success": returncode == 0,
             "stdout": stdout,

--- a/netexec/test/helpers/test_netexec_command_builder.py
+++ b/netexec/test/helpers/test_netexec_command_builder.py
@@ -204,3 +204,28 @@ class NetExecCommandBuilderTest(TestCase):
     def test_extract_module_unknown_safe_key_raises(self):
         with self.assertRaises(ValueError):
             extract_data_module({}, "smb", "nonexistent_module_xyz")
+
+    def test_extract_module_spider_plus_forces_output_folder(self):
+        content = {"username": "admin", "password": "pass"}
+        data = extract_data_module(content, "smb", "spider_plus")
+        self.assertIn("spider_output_dir", data)
+        self.assertTrue(data["spider_output_dir"].startswith("/tmp/nxc_spider_plus_"))
+        # The controlled folder is passed to netexec as a module option.
+        o_idx = data["extra_args"].index("-o")
+        opts_after = data["extra_args"][o_idx + 1 :]
+        self.assertIn(f"OUTPUT_FOLDER={data['spider_output_dir']}", opts_after)
+
+    def test_extract_module_spider_plus_overrides_user_output_folder(self):
+        content = {
+            "username": "admin",
+            "password": "pass",
+            "mo_spider_plus_OUTPUT_FOLDER": "/home/attacker/loot",
+        }
+        data = extract_data_module(content, "smb", "spider_plus")
+        o_idx = data["extra_args"].index("-o")
+        opts_after = data["extra_args"][o_idx + 1 :]
+        folders = [o for o in opts_after if o.startswith("OUTPUT_FOLDER=")]
+        # Exactly one OUTPUT_FOLDER, and it is the controlled temp dir, never the
+        # user-supplied one (which we could not read back reliably).
+        self.assertEqual(folders, [f"OUTPUT_FOLDER={data['spider_output_dir']}"])
+        self.assertNotIn("OUTPUT_FOLDER=/home/attacker/loot", opts_after)

--- a/netexec/test/helpers/test_spider_plus_parser.py
+++ b/netexec/test/helpers/test_spider_plus_parser.py
@@ -1,0 +1,88 @@
+import json
+import os
+import tempfile
+from unittest import TestCase
+
+from netexec.helpers.spider_plus_parser import (
+    extract_files_from_metadata,
+    parse_spider_output_dir,
+)
+
+# Trimmed real spider_plus metadata: a top-level file on NETLOGON and a
+# deeply-nested file on SYSVOL.
+_SAMPLE = {
+    "NETLOGON": {
+        "script.ps1": {"size": "165 B"},
+        "secret.ps1": {"size": "869 B"},
+    },
+    "SYSVOL": {
+        "north.sevenkingdoms.local/scripts/secret.ps1": {"size": "869 B"},
+    },
+}
+
+
+class SpiderPlusParserTest(TestCase):
+
+    def setUp(self):
+        self.ip = "74.234.220.121"
+        self.ip_map = {self.ip: "asset-001"}
+
+    def _by_name(self, findings, name):
+        return [f for f in findings if f["file_name"] == name]
+
+    def test_extract_basename_and_directory(self):
+        findings = extract_files_from_metadata(_SAMPLE, self.ip, self.ip_map)
+        nested = self._by_name(findings, "secret.ps1")
+        sysvol = [f for f in nested if f["share"] == "SYSVOL"][0]
+        self.assertEqual(sysvol["file_name"], "secret.ps1")
+        self.assertEqual(sysvol["path"], "north.sevenkingdoms.local/scripts")
+        self.assertEqual(sysvol["share"], "SYSVOL")
+        self.assertEqual(sysvol["host"], self.ip)
+        self.assertEqual(sysvol["asset_id"], "asset-001")
+
+    def test_top_level_file_has_empty_path(self):
+        findings = extract_files_from_metadata(_SAMPLE, self.ip, self.ip_map)
+        netlogon = [f for f in findings if f["share"] == "NETLOGON"]
+        self.assertEqual(
+            {f["file_name"] for f in netlogon}, {"script.ps1", "secret.ps1"}
+        )
+        self.assertTrue(all(f["path"] == "" for f in netlogon))
+
+    def test_share_hosted_files_keep_distinct_findings_per_share(self):
+        # Same basename on two shares must stay two findings (share differs), so
+        # the platform's full-path value never collapses them.
+        findings = extract_files_from_metadata(_SAMPLE, self.ip, self.ip_map)
+        secrets = self._by_name(findings, "secret.ps1")
+        self.assertEqual({f["share"] for f in secrets}, {"NETLOGON", "SYSVOL"})
+
+    def test_no_asset_id_when_unmapped(self):
+        findings = extract_files_from_metadata(_SAMPLE, self.ip, {})
+        self.assertTrue(all("asset_id" not in f for f in findings))
+
+    def test_empty_or_malformed_metadata(self):
+        self.assertEqual(extract_files_from_metadata({}, self.ip, self.ip_map), [])
+        self.assertEqual(
+            extract_files_from_metadata({"SHARE": "not-a-dict"}, self.ip, self.ip_map),
+            [],
+        )
+
+    def test_parse_output_dir_reads_ip_named_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, f"{self.ip}.json"), "w", encoding="utf-8") as f:
+                json.dump(_SAMPLE, f)
+            # A non-JSON file must be ignored.
+            with open(os.path.join(d, "readme.txt"), "w", encoding="utf-8") as f:
+                f.write("ignore me")
+            findings = parse_spider_output_dir(d, self.ip_map)
+        self.assertTrue(findings)
+        self.assertTrue(all(f["host"] == self.ip for f in findings))
+        self.assertTrue(all(f["asset_id"] == "asset-001" for f in findings))
+
+    def test_parse_missing_dir_returns_empty(self):
+        self.assertEqual(parse_spider_output_dir("/no/such/dir", self.ip_map), [])
+
+    def test_parse_malformed_json_skipped(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "10.0.0.1.json"), "w", encoding="utf-8") as f:
+                f.write("{ not valid json")
+            self.assertEqual(parse_spider_output_dir(d, self.ip_map), [])


### PR DESCRIPTION
Closes #390

Emits structured `file` findings from the NetExec `spider_plus` module.

## Why
`spider_plus` recursively enumerates files on readable SMB shares — exactly the attack step where a red team turns share access into loot (e.g. a `secret.ps1` on `SYSVOL` holding a hard-coded password). Until now the module produced only generic `text` output, so those files never became findings and could not appear in the attack-path graph.

This unlocks the kill-chain: **nmap → 445 → SMB → enum shares (`share` finding) → spider_plus (`file` findings on that share)**.

## The catch, and how it's handled
`spider_plus` prints only aggregate stats to stdout; the per-file list is written to a JSON metadata file per target (`<ip>.json`) in its output folder. So this cannot go through the stdout parser:

- The command builder forces a controlled `OUTPUT_FOLDER` for `spider_plus` (overriding any user-supplied one) so the injector knows where to read the metadata back from.
- After execution, `openaev_netexec` reads every `<ip>.json`, merges the files into the structured outputs as `files`, then cleans the folder up.
- `spider_plus_parser` flattens the `{share: {path: meta}}` metadata into file findings, keeping **`file_name`** (basename), **`path`** (directory), **`share`** and **`host`** as distinct fields — so a share-hosted file links back to its `share` finding, and local files (no share, e.g. FTP/NFS `--ls` later) stay distinguishable.

## Tests
- `test_spider_plus_parser`: basename/directory split, top-level vs nested files, same basename kept distinct per share, asset-id mapping, missing/malformed metadata.
- `test_netexec_command_builder`: `spider_plus` forces the controlled `OUTPUT_FOLDER` and overrides a user-supplied one.
- Full suite: 122 passed. black + isort + flake8 clean.

## Dependency
Requires the `file` output type added in client-python (OpenAEV-Platform/client-python#322) — `contract_outputs` references `ContractOutputType.File`. Part of the attack-path file finding work (OpenAEV #6647).