### PR TITLE
chore(injectors): comment out EE-only tenant_id in sample configs and docker compose examples (#393)

### DIFF
--- a/ai-redteam/.env.sample
+++ b/ai-redteam/.env.sample
@@ -4,7 +4,8 @@
 # base URL to reach the OpenAEV server (must be routable from inside the container)
 OPENAEV_URL=ChangeMe
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # injector ID must be a unique string, e.g. UUIDv4
 INJECTOR_ID=ChangeMe

--- a/ai-redteam/ai_redteam/config.yml.sample
+++ b/ai-redteam/ai_redteam/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 injector:
   id: 'ChangeMe'   # unique UUIDv4

--- a/ai-redteam/docker-compose.yml
+++ b/ai-redteam/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - INJECTOR_ID=${INJECTOR_ID}
       - INJECTOR_NAME=${INJECTOR_NAME:-"AI Red Team"}
       - INJECTOR_LOG_LEVEL=${INJECTOR_LOG_LEVEL:-warn}

--- a/aws/.env.sample
+++ b/aws/.env.sample
@@ -5,7 +5,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # INJECTOR Environment Variables
 INJECTOR_ID=aws--ChangeMe

--- a/aws/config.yml.sample
+++ b/aws/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 injector:
   id: 'ChangeMe'

--- a/aws/docker-compose.yml
+++ b/aws/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - INJECTOR_ID=${INJECTOR_ID}
       - INJECTOR_NAME=${INJECTOR_NAME}
       - INJECTOR_LOG_LEVEL=${INJECTOR_LOG_LEVEL}

--- a/censys/.env.sample
+++ b/censys/.env.sample
@@ -5,7 +5,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # INJECTOR Environment Variables
 INJECTOR_ID=censys--ChangeMe

--- a/censys/config.yml.sample
+++ b/censys/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 injector:
   id: 'ChangeMe'

--- a/censys/docker-compose.yml
+++ b/censys/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - INJECTOR_ID=${INJECTOR_ID}
       - INJECTOR_NAME=${INJECTOR_NAME}
       - INJECTOR_LOG_LEVEL=${INJECTOR_LOG_LEVEL}

--- a/email-google-workspace/.env.sample
+++ b/email-google-workspace/.env.sample
@@ -5,7 +5,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # INJECTOR Environment Variables
 INJECTOR_ID=email-google-workspace--ChangeMe

--- a/email-google-workspace/config.yml.sample
+++ b/email-google-workspace/config.yml.sample
@@ -1,6 +1,7 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
   # tenant_id: 'ChangeMe'
 
 injector:

--- a/email-google-workspace/docker-compose.yml
+++ b/email-google-workspace/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - INJECTOR_ID=${INJECTOR_ID}
       - INJECTOR_NAME=${INJECTOR_NAME}
       - INJECTOR_LOG_LEVEL=${INJECTOR_LOG_LEVEL}

--- a/email-m365/.env.sample
+++ b/email-m365/.env.sample
@@ -5,7 +5,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # INJECTOR Environment Variables
 # Replace with a unique UUIDv4 for this injector instance.

--- a/email-m365/config.yml.sample
+++ b/email-m365/config.yml.sample
@@ -1,6 +1,7 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
   # tenant_id: 'ChangeMe'
 
 injector:

--- a/email-m365/docker-compose.yml
+++ b/email-m365/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - INJECTOR_ID=${INJECTOR_ID}
       - INJECTOR_NAME=${INJECTOR_NAME}
       - INJECTOR_LOG_LEVEL=${INJECTOR_LOG_LEVEL}

--- a/email/.env.sample
+++ b/email/.env.sample
@@ -5,7 +5,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # INJECTOR Environment Variables
 INJECTOR_ID=email--ChangeMe

--- a/email/config.yml.sample
+++ b/email/config.yml.sample
@@ -1,6 +1,7 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
   # tenant_id: 'ChangeMe'
 
 injector:

--- a/email/docker-compose.yml
+++ b/email/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      #- OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - INJECTOR_ID=${INJECTOR_ID}
       - INJECTOR_NAME=${INJECTOR_NAME}
       #- INJECTOR_LOG_LEVEL=${INJECTOR_LOG_LEVEL}

--- a/http-query/.env.sample
+++ b/http-query/.env.sample
@@ -5,7 +5,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # INJECTOR Environment Variables
 INJECTOR_ID=http-query--ChangeMe

--- a/http-query/config.yml.sample
+++ b/http-query/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 injector:
   id: 'ChangeMe'

--- a/http-query/docker-compose.yml
+++ b/http-query/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - INJECTOR_ID=${INJECTOR_ID}
       - INJECTOR_NAME=${INJECTOR_NAME}
       - INJECTOR_LOG_LEVEL=${INJECTOR_LOG_LEVEL}

--- a/netexec/.env.sample
+++ b/netexec/.env.sample
@@ -5,7 +5,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # INJECTOR Environment Variables
 INJECTOR_ID=netexec--ChangeMe

--- a/netexec/config.yml.sample
+++ b/netexec/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 injector:
   id: 'ChangeMe'

--- a/netexec/docker-compose.yml
+++ b/netexec/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - INJECTOR_ID=${INJECTOR_ID}
       - INJECTOR_NAME=${INJECTOR_NAME}
       - INJECTOR_LOG_LEVEL=${INJECTOR_LOG_LEVEL}

--- a/nmap/.env.sample
+++ b/nmap/.env.sample
@@ -5,7 +5,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # INJECTOR Environment Variables
 INJECTOR_ID=nmap--ChangeMe

--- a/nmap/config.yml.sample
+++ b/nmap/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 injector:
   id: 'ChangeMe'

--- a/nmap/docker-compose.yml
+++ b/nmap/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - INJECTOR_ID=${INJECTOR_ID}
       - INJECTOR_NAME=${INJECTOR_NAME}
       - INJECTOR_LOG_LEVEL=${INJECTOR_LOG_LEVEL}

--- a/nuclei/.env.sample
+++ b/nuclei/.env.sample
@@ -5,7 +5,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # INJECTOR Environment Variables
 INJECTOR_ID=nuclei--ChangeMe

--- a/nuclei/config.yml.sample
+++ b/nuclei/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: "ChangeMe"
   token: "ChangeMe"
-  tenant_id: "ChangeMe"
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: "ChangeMe"
 
 injector:
   id: "nuclei--ChangeMe"

--- a/nuclei/docker-compose.yml
+++ b/nuclei/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - INJECTOR_ID=${INJECTOR_ID}
       - INJECTOR_NAME=${INJECTOR_NAME}
       - INJECTOR_LOG_LEVEL=${INJECTOR_LOG_LEVEL}

--- a/shodan/.env.sample
+++ b/shodan/.env.sample
@@ -5,7 +5,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # INJECTOR Environment Variables
 INJECTOR_ID=ChangeMe

--- a/shodan/config.yml.sample
+++ b/shodan/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'ChangeMe'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 injector:
   id: 'ChangeMe'

--- a/shodan/docker-compose.yml
+++ b/shodan/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - INJECTOR_ID=${INJECTOR_ID}
       - INJECTOR_NAME=${INJECTOR_NAME}
       - INJECTOR_LOG_LEVEL=${INJECTOR_LOG_LEVEL}

--- a/stratus/.env.sample
+++ b/stratus/.env.sample
@@ -5,7 +5,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # INJECTOR Environment Variables
 INJECTOR_ID=stratus--ChangeMe

--- a/stratus/config.yml.sample
+++ b/stratus/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 injector:
   id: 'ChangeMe'

--- a/stratus/docker-compose.yml
+++ b/stratus/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - INJECTOR_ID=${INJECTOR_ID}
       - INJECTOR_NAME=${INJECTOR_NAME}
       - INJECTOR_LOG_LEVEL=${INJECTOR_LOG_LEVEL}


### PR DESCRIPTION
## Summary

- Comment out the OpenAEV `tenant_id` / `OPENAEV_TENANT_ID` parameter in all `.env.sample`, `config.yml.sample` and `docker-compose.yml` files, since it is only required for multi-tenancy (Enterprise Edition) and most EE users deploy injectors through the catalog rather than manual docker compose deployments.
- Add a uniform note above every commented occurrence: "only required for multi-tenancy (Enterprise Edition), keep commented otherwise".
- Vendor-specific `tenant_id` parameters (Microsoft Entra ID tenant for `email-m365` and `teams`) are left untouched.

No functional change: the parameter was already documented as optional in the README configuration tables; the samples now match.

## Test plan

- [ ] `rg "^OPENAEV_TENANT_ID=" -g "*.sample"` returns no active occurrence
- [ ] `rg "^\s*- OPENAEV_TENANT_ID=" -g "docker-compose*.yml"` returns no active occurrence
- [ ] No active `tenant_id` remains under the `openaev:` section of any `config.yml.sample`
- [ ] Microsoft Entra `tenant_id` in `email-m365` and `teams` samples is unchanged

Closes #393
