### PR TITLE
feat(injectors): emit findings from Shodan and NetExec vulnerability modules (#397)

### DIFF
--- a/netexec/netexec/contracts/output_registry.py
+++ b/netexec/netexec/contracts/output_registry.py
@@ -127,17 +127,21 @@ _MODULE_OUTPUTS = {
     "enum_logins": {ACTION_OUTPUT},
     "pso": {ACTION_OUTPUT},
     "maq": {ACTION_OUTPUT},
-    # Vulnerability / exploit detection
-    "ms17_010": {ACTION_OUTPUT},
-    "smbghost": {ACTION_OUTPUT},
-    "zerologon": {ACTION_OUTPUT},
-    "nopac": {ACTION_OUTPUT},
-    "printnightmare": {ACTION_OUTPUT},
-    "petitpotam": {ACTION_OUTPUT},
-    "shadowcoerce": {ACTION_OUTPUT},
-    "dfscoerce": {ACTION_OUTPUT},
+    # Vulnerability / exploit detection. Modules that print an explicit
+    # "VULNERABLE" verdict emit a VULNERABILITY finding (shared verdict
+    # extractor). webdav / ntlmv1 / timeroast stay action_output-only: their
+    # positive output is not a VULNERABLE verdict, so it needs dedicated
+    # parsing (TODO).
+    "ms17_010": {ACTION_OUTPUT, VULNERABILITY},
+    "smbghost": {ACTION_OUTPUT, VULNERABILITY},
+    "zerologon": {ACTION_OUTPUT, VULNERABILITY},
+    "nopac": {ACTION_OUTPUT, VULNERABILITY},
+    "printnightmare": {ACTION_OUTPUT, VULNERABILITY},
+    "petitpotam": {ACTION_OUTPUT, VULNERABILITY},
+    "shadowcoerce": {ACTION_OUTPUT, VULNERABILITY},
+    "dfscoerce": {ACTION_OUTPUT, VULNERABILITY},
     "coerce_plus": {ACTION_OUTPUT, VULNERABILITY},
-    "printerbug": {ACTION_OUTPUT},
+    "printerbug": {ACTION_OUTPUT, VULNERABILITY},
     "spooler": {ACTION_OUTPUT, VULNERABILITY},
     "webdav": {ACTION_OUTPUT},
     "ntlmv1": {ACTION_OUTPUT},

--- a/netexec/netexec/helpers/credential_extractors.py
+++ b/netexec/netexec/helpers/credential_extractors.py
@@ -1256,6 +1256,69 @@ def extract_mod_ldap_checker_vulnerabilities(
     return results
 
 
+# -------------------------------------------------------------------
+# Generic vulnerability verdict (VULNERABLE / NOT VULNERABLE)
+# -------------------------------------------------------------------
+# Many netexec vulnerability-check / coercion modules (ms17_010, zerologon,
+# nopac, printnightmare, petitpotam, smbghost, dfscoerce, shadowcoerce,
+# printerbug) print an explicit "VULNERABLE" verdict line when the target is
+# affected. One shared extractor turns that verdict into a vulnerability finding
+# named after the technique (deduplicated per host) so these checks stop being
+# plain text and start feeding the attack path. A "NOT VULNERABLE" line, or any
+# line without the verdict, never yields a finding.
+_VULNERABLE_VERDICT_RE = re.compile(r"\bvulnerable\b", re.IGNORECASE)
+_NOT_VULNERABLE_VERDICT_RE = re.compile(r"\bnot\s+vulnerable\b", re.IGNORECASE)
+
+
+def _make_verdict_vulnerability_extractor(display_name: str):
+    """Build an extractor that emits a vulnerability finding on a VULNERABLE line."""
+
+    def _extractor(
+        finding_lines: list[tuple[str, str, str]],
+        ip_to_asset_id_map: dict,
+    ) -> list[dict]:
+        results: list[dict] = []
+        seen: set[tuple[str, str]] = set()
+        for ip, hostname, rest in finding_lines:
+            if not _VULNERABLE_VERDICT_RE.search(rest):
+                continue
+            if _NOT_VULNERABLE_VERDICT_RE.search(rest):
+                continue
+            key = (ip, hostname)
+            if key in seen:
+                continue
+            seen.add(key)
+            finding: dict = {
+                "name": display_name,
+                "status": "VULNERABLE",
+                "details": rest,
+                "host": ip,
+                "hostname": hostname,
+                "source_line": rest,
+            }
+            asset_id = ip_to_asset_id_map.get(ip, "")
+            if asset_id:
+                finding["asset_id"] = asset_id
+            results.append(finding)
+        return results
+
+    return _extractor
+
+
+# Technique display names for the shared VULNERABLE-verdict extractor.
+_VERDICT_VULNERABILITY_MODULES = {
+    "ms17_010": "MS17-010 (EternalBlue)",
+    "smbghost": "SMBGhost (CVE-2020-0796)",
+    "zerologon": "Zerologon (CVE-2020-1472)",
+    "nopac": "noPac (CVE-2021-42278/42287)",
+    "printnightmare": "PrintNightmare (CVE-2021-1675/34527)",
+    "petitpotam": "PetitPotam",
+    "shadowcoerce": "ShadowCoerce",
+    "dfscoerce": "DFSCoerce",
+    "printerbug": "PrinterBug",
+}
+
+
 # ===================================================================
 # Registry: (family, identifier) -> dedicated extractor function
 # ===================================================================
@@ -1328,6 +1391,10 @@ _VULNERABILITY_EXTRACTORS = {
     ("module", "spooler"): extract_mod_spooler_vulnerabilities,
     ("module", "coerce_plus"): extract_mod_coerce_plus_vulnerabilities,
     ("module", "ldap_checker"): extract_mod_ldap_checker_vulnerabilities,
+    **{
+        ("module", module): _make_verdict_vulnerability_extractor(name)
+        for module, name in _VERDICT_VULNERABILITY_MODULES.items()
+    },
 }
 
 

--- a/netexec/netexec/helpers/credential_extractors.py
+++ b/netexec/netexec/helpers/credential_extractors.py
@@ -1278,16 +1278,21 @@ def _make_verdict_vulnerability_extractor(display_name: str):
         ip_to_asset_id_map: dict,
     ) -> list[dict]:
         results: list[dict] = []
-        seen: set[tuple[str, str]] = set()
+        seen: set[str] = set()
         for ip, hostname, rest in finding_lines:
             if not _VULNERABLE_VERDICT_RE.search(rest):
                 continue
             if _NOT_VULNERABLE_VERDICT_RE.search(rest):
                 continue
-            key = (ip, hostname)
-            if key in seen:
+            # An unparseable line yields ip == "": a verdict with no host cannot
+            # feed the attack path and would create an invalid empty-host finding.
+            if not ip:
                 continue
-            seen.add(key)
+            # Deduplicate per host: the finding is named after the technique, so a
+            # single VULNERABLE line per host is enough regardless of hostname.
+            if ip in seen:
+                continue
+            seen.add(ip)
             finding: dict = {
                 "name": display_name,
                 "status": "VULNERABLE",

--- a/netexec/test/helpers/test_credential_extractors.py
+++ b/netexec/test/helpers/test_credential_extractors.py
@@ -351,6 +351,43 @@ class CredentialExtractorsTest(TestCase):
         self.assertEqual(results, [])
 
     # ----------------------------------------------------------------
+    # Shared VULNERABLE-verdict extractor (ms17_010, zerologon, ...)
+    # ----------------------------------------------------------------
+
+    def test_verdict_extractor_emits_named_vulnerability(self):
+        extractor = get_vulnerability_extractor("module", "ms17_010")
+        self.assertIsNotNone(extractor)
+        lines = self._lines("Host is likely VULNERABLE to MS17-010! (Windows 7)")
+        results = extractor(lines, self.ip_map)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["name"], "MS17-010 (EternalBlue)")
+        self.assertEqual(results[0]["status"], "VULNERABLE")
+        self.assertEqual(results[0]["host"], self.ip)
+        self.assertEqual(results[0]["asset_id"], "asset-001")
+
+    def test_verdict_extractor_ignores_not_vulnerable(self):
+        extractor = get_vulnerability_extractor("module", "zerologon")
+        results = extractor(self._lines("Target is NOT VULNERABLE"), self.ip_map)
+        self.assertEqual(results, [])
+
+    def test_verdict_extractor_ignores_unrelated_line(self):
+        extractor = get_vulnerability_extractor("module", "nopac")
+        results = extractor(self._lines("Some unrelated output line"), self.ip_map)
+        self.assertEqual(results, [])
+
+    def test_verdict_extractor_dedupes_per_host(self):
+        extractor = get_vulnerability_extractor("module", "printnightmare")
+        lines = self._lines("VULNERABLE", "VULNERABLE, second line")
+        results = extractor(lines, self.ip_map)
+        self.assertEqual(len(results), 1)
+
+    def test_verdict_extractor_no_asset_id_when_unmapped(self):
+        extractor = get_vulnerability_extractor("module", "petitpotam")
+        results = extractor(self._lines("VULNERABLE"), self.empty_ip_map)
+        self.assertEqual(len(results), 1)
+        self.assertNotIn("asset_id", results[0])
+
+    # ----------------------------------------------------------------
     # Registry getters
     # ----------------------------------------------------------------
 

--- a/netexec/test/helpers/test_credential_extractors.py
+++ b/netexec/test/helpers/test_credential_extractors.py
@@ -387,6 +387,24 @@ class CredentialExtractorsTest(TestCase):
         self.assertEqual(len(results), 1)
         self.assertNotIn("asset_id", results[0])
 
+    def test_verdict_extractor_skips_line_without_host(self):
+        extractor = get_vulnerability_extractor("module", "ms17_010")
+        # Unparseable lines surface with ip == "" (no host prefix); a verdict
+        # there must not yield an invalid finding with an empty host.
+        results = extractor([("", "", "Host is VULNERABLE")], self.ip_map)
+        self.assertEqual(results, [])
+
+    def test_verdict_extractor_dedupes_per_host_across_hostnames(self):
+        extractor = get_vulnerability_extractor("module", "zerologon")
+        # Same host IP, different hostname spellings -> still one finding.
+        lines = [
+            (self.ip, "WINTERFELL", "VULNERABLE"),
+            (self.ip, "winterfell.north.local", "VULNERABLE"),
+        ]
+        results = extractor(lines, self.ip_map)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["host"], self.ip)
+
     # ----------------------------------------------------------------
     # Registry getters
     # ----------------------------------------------------------------

--- a/shodan/shodan/contracts/shodan_contracts.py
+++ b/shodan/shodan/contracts/shodan_contracts.py
@@ -256,7 +256,30 @@ class ShodanContracts:
             isFindingCompatible=False,
             labels=["shodan"],
         )
-        return [output_assets]
+        # Findings emitted on every run (independent of asset auto-creation) so the
+        # discovered exposure can fuel the AI attack path: hosts, open ports and CVEs.
+        output_hosts = ContractOutputElement(
+            type=ContractOutputType.IPv4,
+            field="hosts",
+            isMultiple=True,
+            isFindingCompatible=True,
+            labels=["shodan"],
+        )
+        output_ports = ContractOutputElement(
+            type=ContractOutputType.Port,
+            field="ports",
+            isMultiple=True,
+            isFindingCompatible=True,
+            labels=["shodan"],
+        )
+        output_cves = ContractOutputElement(
+            type=ContractOutputType.CVE,
+            field="cves",
+            isMultiple=True,
+            isFindingCompatible=True,
+            labels=["shodan"],
+        )
+        return [output_assets, output_hosts, output_ports, output_cves]
 
     def _build_contract(
         self,

--- a/shodan/shodan/injector/openaev_shodan.py
+++ b/shodan/shodan/injector/openaev_shodan.py
@@ -133,6 +133,11 @@ class ShodanInjector:
 
         results = shodan_results.get("data", [])
         found_assets_list = []
+        # Findings are collected across every result element, deduplicated, and emitted on
+        # every run regardless of asset auto-creation (assets need a hostname; findings do not).
+        hosts: set[str] = set()
+        ports: set[int] = set()
+        cves: set[str] = set()
 
         for item in results:
             result = item.get("result", {})
@@ -160,6 +165,21 @@ class ShodanInjector:
                 hostnames = element.get("hostnames", [])
                 os = element.get("os", "Unknown")
 
+                # Collect findings BEFORE the hostname guard below: a banner with no
+                # hostname still carries a host IP, an open port and possibly CVEs.
+                if ip_str:
+                    hosts.add(ip_str)
+                port = element.get("port")
+                if isinstance(port, bool):
+                    port = None
+                if isinstance(port, int):
+                    ports.add(port)
+                elif isinstance(port, str) and port.isdigit():
+                    ports.add(int(port))
+                for cve_id in element.get("vulns") or {}:
+                    if cve_id:
+                        cves.add(str(cve_id).upper())
+
                 if not ip_str or not hostnames:
                     continue
 
@@ -184,9 +204,19 @@ class ShodanInjector:
 
         self.helper.injector_logger.info(
             f"{LOG_PREFIX} - Structured output preparation and asset generation completed successfully.",
-            {"total_assets_generated": len(aggregate_assets)},
+            {
+                "total_assets_generated": len(aggregate_assets),
+                "total_hosts": len(hosts),
+                "total_ports": len(ports),
+                "total_cves": len(cves),
+            },
         )
-        return {"found_assets": aggregate_assets}
+        return {
+            "found_assets": aggregate_assets,
+            "hosts": sorted(hosts),
+            "ports": sorted(ports),
+            "cves": sorted(cves),
+        }
 
     def _resolve_assets(self, data: dict, selector_key: str) -> list[dict]:
 
@@ -441,10 +471,17 @@ class ShodanInjector:
             self.shodan_client_api.process_shodan_search(normalize_input_data)
         )
 
-        # Preparation and creation of auto_create_assets
-        output_structured = ""
+        # Structured output: findings (hosts / ports / CVEs) are ALWAYS emitted so the AI
+        # attack path can lateralize on the discovered exposure. Asset auto-creation stays
+        # opt-in (auto_create_assets), so found_assets is only included when requested.
+        structured = self._prepare_output_structured(shodan_results)
+        output_structured = {
+            "hosts": structured["hosts"],
+            "ports": structured["ports"],
+            "cves": structured["cves"],
+        }
         if normalize_input_data.inject_content.auto_create_assets:
-            output_structured = self._prepare_output_structured(shodan_results)
+            output_structured["found_assets"] = structured["found_assets"]
 
         # Preparation and creation of output_message
         output_message = self._prepare_output_message(

--- a/shodan/shodan/injector/openaev_shodan.py
+++ b/shodan/shodan/injector/openaev_shodan.py
@@ -1,4 +1,6 @@
+import ipaddress
 import json
+import re
 import time
 from datetime import datetime, timezone
 from urllib.parse import urlparse
@@ -27,6 +29,18 @@ from shodan.models import (
 from shodan.services import ShodanClientAPI, Utils
 
 LOG_PREFIX = "[SHODAN_INJECTOR]"
+
+# Shodan `vulns` keys are CVE identifiers; only emit contract-valid CVEs.
+_CVE_RE = re.compile(r"^CVE-\d{4}-\d{4,}$")
+
+
+def _is_valid_ipv4(value: str) -> bool:
+    """Return True if *value* is a valid IPv4 address (the `hosts` output type)."""
+    try:
+        ipaddress.IPv4Address(value)
+    except ValueError:
+        return False
+    return True
 
 
 class ShodanInjector:
@@ -167,18 +181,24 @@ class ShodanInjector:
 
                 # Collect findings BEFORE the hostname guard below: a banner with no
                 # hostname still carries a host IP, an open port and possibly CVEs.
-                if ip_str:
+                # Validate against the declared contract output types (IPv4 / Port /
+                # CVE) so Shodan noise (IPv6, malformed IPs, out-of-range ports or
+                # non-CVE vuln keys) never yields contract-incompatible findings.
+                if ip_str and _is_valid_ipv4(ip_str):
                     hosts.add(ip_str)
                 port = element.get("port")
                 if isinstance(port, bool):
                     port = None
-                if isinstance(port, int):
-                    ports.add(port)
                 elif isinstance(port, str) and port.isdigit():
-                    ports.add(int(port))
+                    port = int(port)
+                if isinstance(port, int) and 1 <= port <= 65535:
+                    ports.add(port)
                 for cve_id in element.get("vulns") or {}:
-                    if cve_id:
-                        cves.add(str(cve_id).upper())
+                    if not cve_id:
+                        continue
+                    cve_str = str(cve_id).upper()
+                    if _CVE_RE.match(cve_str):
+                        cves.add(cve_str)
 
                 if not ip_str or not hostnames:
                     continue

--- a/shodan/tests/unit/test_openaev_shodan.py
+++ b/shodan/tests/unit/test_openaev_shodan.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import shodan.injector.openaev_shodan as module
+from shodan.contracts import InjectorKey
 
 
 @patch.object(module, "ShodanClientAPI")
@@ -211,3 +212,120 @@ class TestShodanInjector(unittest.TestCase):
                 },
             ],
         )
+
+    # ----------------------------------------------------------------
+    # Findings collection (_prepare_output_structured)
+    # ----------------------------------------------------------------
+
+    @staticmethod
+    def _results(*matches):
+        return {"data": [{"url": None, "result": {"matches": list(matches)}}]}
+
+    def test_prepare_output_structured_validates_findings(self, m_api):
+        injector = module.ShodanInjector(config=MagicMock(), helper=MagicMock())
+
+        shodan_results = self._results(
+            {
+                "ip_str": "51.38.220.153",
+                "hostnames": ["automation.filigran.io"],
+                "port": 443,
+                "vulns": {"CVE-2023-44487": {}, "cve-2025-23419": {}},
+            },
+            # No hostname: a banner still yields host / port / CVE findings.
+            {
+                "ip_str": "142.250.80.46",
+                "hostnames": [],
+                "port": "80",
+                "vulns": {"CVE-2019-8936": {}, "NOT-A-CVE": {}},
+            },
+            # IPv6 and malformed IPs are dropped from the IPv4 `hosts` output.
+            {"ip_str": "2001:db8::1", "hostnames": [], "port": 22},
+            {"ip_str": "not-an-ip", "hostnames": [], "port": 70000},
+            # Booleans and out-of-range ports never reach the Port output.
+            {"ip_str": "8.8.8.8", "hostnames": [], "port": True},
+        )
+
+        structured = injector._prepare_output_structured(shodan_results)
+
+        self.assertEqual(
+            structured["hosts"], ["142.250.80.46", "51.38.220.153", "8.8.8.8"]
+        )
+        self.assertEqual(structured["ports"], [22, 80, 443])
+        self.assertEqual(
+            structured["cves"],
+            ["CVE-2019-8936", "CVE-2023-44487", "CVE-2025-23419"],
+        )
+
+    def test_prepare_output_structured_deduplicates_findings(self, m_api):
+        injector = module.ShodanInjector(config=MagicMock(), helper=MagicMock())
+
+        shodan_results = self._results(
+            {
+                "ip_str": "1.1.1.1",
+                "hostnames": [],
+                "port": 443,
+                "vulns": {"CVE-2023-1111": {}},
+            },
+            {
+                "ip_str": "1.1.1.1",
+                "hostnames": [],
+                "port": 443,
+                "vulns": {"CVE-2023-1111": {}},
+            },
+        )
+
+        structured = injector._prepare_output_structured(shodan_results)
+
+        self.assertEqual(structured["hosts"], ["1.1.1.1"])
+        self.assertEqual(structured["ports"], [443])
+        self.assertEqual(structured["cves"], ["CVE-2023-1111"])
+        self.assertEqual(structured["found_assets"], [])
+
+    # ----------------------------------------------------------------
+    # Findings are always emitted; assets stay opt-in (_shodan_execution)
+    # ----------------------------------------------------------------
+
+    def _run_execution(self, injector, *, auto_create_assets):
+        structured = {
+            "found_assets": [{"name": "host.local"}],
+            "hosts": ["1.2.3.4"],
+            "ports": [443],
+            "cves": ["CVE-2023-1111"],
+        }
+        data = {
+            "injection": {
+                "inject_content": {
+                    InjectorKey.TARGET_SELECTOR_KEY: "manual",
+                    InjectorKey.TARGET_PROPERTY_SELECTOR_KEY: "automatic",
+                }
+            }
+        }
+        normalize_input_data = MagicMock()
+        normalize_input_data.inject_content.auto_create_assets = auto_create_assets
+        injector.shodan_client_api.process_shodan_search.return_value = ({}, {})
+        with patch.object(
+            injector, "_normalize_input_data", return_value=normalize_input_data
+        ), patch.object(
+            injector, "_prepare_output_structured", return_value=structured
+        ), patch.object(
+            injector, "_prepare_output_message", return_value="message"
+        ):
+            return injector._shodan_execution(data)
+
+    def test_shodan_execution_emits_findings_without_assets(self, m_api):
+        injector = module.ShodanInjector(config=MagicMock(), helper=MagicMock())
+
+        output_structured, _ = self._run_execution(injector, auto_create_assets=False)
+
+        self.assertEqual(output_structured["hosts"], ["1.2.3.4"])
+        self.assertEqual(output_structured["ports"], [443])
+        self.assertEqual(output_structured["cves"], ["CVE-2023-1111"])
+        self.assertNotIn("found_assets", output_structured)
+
+    def test_shodan_execution_includes_assets_when_opted_in(self, m_api):
+        injector = module.ShodanInjector(config=MagicMock(), helper=MagicMock())
+
+        output_structured, _ = self._run_execution(injector, auto_create_assets=True)
+
+        self.assertEqual(output_structured["found_assets"], [{"name": "host.local"}])
+        self.assertEqual(output_structured["hosts"], ["1.2.3.4"])

--- a/shodan/tests/unit/test_shodan_contracts_outputs.py
+++ b/shodan/tests/unit/test_shodan_contracts_outputs.py
@@ -1,0 +1,30 @@
+import unittest
+
+from pyoaev.contracts.contract_config import ContractOutputType
+
+from shodan.contracts.shodan_contracts import ShodanContracts
+
+
+class TestShodanContractOutputs(unittest.TestCase):
+    """The Shodan contracts must expose IPv4 / Port / CVE finding-compatible
+    outputs so discovered exposure can feed the AI attack path, while assets
+    stay a non-finding output."""
+
+    def setUp(self):
+        self.outputs = {out.field: out for out in ShodanContracts._base_outputs()}
+
+    def test_declares_finding_compatible_hosts_ports_cves(self):
+        expected_types = {
+            "hosts": ContractOutputType.IPv4,
+            "ports": ContractOutputType.Port,
+            "cves": ContractOutputType.CVE,
+        }
+        for field, output_type in expected_types.items():
+            self.assertIn(field, self.outputs)
+            self.assertEqual(self.outputs[field].type, output_type)
+            self.assertTrue(self.outputs[field].isFindingCompatible)
+            self.assertTrue(self.outputs[field].isMultiple)
+
+    def test_found_assets_is_not_finding_compatible(self):
+        self.assertIn("found_assets", self.outputs)
+        self.assertFalse(self.outputs["found_assets"].isFindingCompatible)


### PR DESCRIPTION
## Summary

Emit structured findings from two offensive injectors so the AI-driven attack path can lateralize on discovered exposure. Closes #397.

- **Shodan**: declares `IPv4` (hosts), `Port` (ports) and `CVE` (cves) finding-compatible contract outputs and emits them on every run, independent of the `auto_create_assets` toggle. Findings are collected before the hostname guard, so a banner with no hostname still yields host/port/CVE findings. Every value is validated against its declared output type before it is emitted: hosts must be valid IPv4 (IPv6 and malformed addresses are dropped), ports must be in 1-65535 (booleans and out-of-range values rejected) and vuln keys must be CVE identifiers. Asset auto-creation stays opt-in.
- **NetExec**: adds one shared "VULNERABLE verdict" extractor that turns an explicit `VULNERABLE` line into a `Vulnerability` finding named after the technique (ignoring `NOT VULNERABLE`), wired into ms17_010, smbghost, zerologon, nopac, printnightmare, petitpotam, shadowcoerce, dfscoerce and printerbug. It skips lines with no host IP (an unparseable line would otherwise create an invalid empty-host finding) and deduplicates per host IP. This reuses the existing `vulnerabilities` dispatcher and contract output element.

## Out of scope

- `webdav`, `ntlmv1`, `timeroast`: their positive output is not a `VULNERABLE` verdict, so they need dedicated parsers (follow-up).
- Collectors: findings stay offensive-only, no changes (maintainer decision).

## Test plan

- [x] `netexec` test suite: 132 passed, including the shared verdict-extractor tests plus new empty-host-skip and per-host-dedupe-across-hostnames cases.
- [x] `shodan` test suite: 34 passed, including new findings validation/dedupe, findings-always-emitted vs opt-in assets, and contract output-type tests.
- [x] black and flake8 clean on changed files.
- [x] Rebased on `main` and resolved the `output_registry.py` conflict from the `text` -> `action_output` rename; the verdict modules now map to `{action_output, vulnerability}`.
- [ ] Reviewer: confirm finding types render as expected in the attack-path UI.
