### PR TITLE
chore: gitignore local spec/planning docs (#405)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ poetry.lock
 
 # Local context docs
 NETEXEC_INJECTOR_CONTEXT.md
+docs/specs/


### PR DESCRIPTION
## Summary
Working docs used to track the input/output typing + TTP mapping rollout (#405, per-injector PRs: #404, #406-#412) are local planning artifacts, not meant to ship as tracked repo content — same treatment as the existing `NETEXEC_INJECTOR_CONTEXT.md` entry.

Closes #405

## Test plan
- N/A — .gitignore only