### PR TITLE
ci: remove redundant apt install of curl and gettext-base (#415)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - run: sudo apt-get update -qq && sudo apt install curl gettext-base
       - run:
           name: install dependencies
           command: pip install black isort --user
@@ -104,10 +103,8 @@ jobs:
             echo "IS_LATEST=$IS_LATEST" >> $BASH_ENV
       - setup_remote_docker
       - run:
-          name: Install environment
+          name: Prepare images directory
           command: |
-            sudo apt-get update -qq
-            sudo apt install curl gettext-base
             mkdir -p ~/openaev/images
       - run:
           working_directory: ~/openaev
@@ -217,7 +214,6 @@ jobs:
     docker:
       - image: cimg/base:current-24.04
     steps:
-      - run: sudo apt-get update -qq && sudo apt install curl gettext-base
       - slack/notify:
           event: pass
           template: basic_success_1
@@ -225,7 +221,6 @@ jobs:
     docker:
       - image: cimg/base:current-24.04
     steps:
-      - run: sudo apt-get update -qq && sudo apt install curl gettext-base
       - slack/notify:
           event: pass
           template: basic_success_1


### PR DESCRIPTION
## Description

Removes the redundant `sudo apt-get update -qq && sudo apt install curl gettext-base` step from the CircleCI jobs that run on `cimg/*` images. Both `curl` and `gettext-base` are already preinstalled in `cimg/python` and `cimg/base`, so the step does nothing useful.

## Motivation

The step is a flaky failure surface. On [job #15408](https://app.circleci.com/pipelines/github/OpenAEV-Platform/injectors/1685/workflows/c88075a7-4ad1-4020-ad87-69ed367dfe95/jobs/15408), `apt-get` stalled on a mirror and hung with no output until CircleCI killed the job after the 10-minute no-output limit (`context deadline exceeded`), before the formatting checks even ran. Removing the step eliminates that failure surface entirely.

## Changes

- `ensure_formatting`: removed the apt step
- `build_docker_images` → `Install environment`: removed the two apt lines, renamed step to `Prepare images directory` (kept the `mkdir`)
- `notify_rolling`: removed the apt step
- `notify`: removed the apt step

The Alpine-based `linter` job (`apk`) is intentionally left unchanged — it uses a different base image without these packages preinstalled.

## Verification

- No `apt` occurrences remain in the affected jobs
- `.circleci/config.yml` still parses as valid YAML

Closes #415