### PR TITLE
fix(injectors): target the seen IP in automatic mode (#417)

### DIFF
--- a/injector_common/injector_common/targets.py
+++ b/injector_common/injector_common/targets.py
@@ -215,14 +215,20 @@ class Targets:
         return None
 
     @staticmethod
-    def is_valid_ip(ip: str) -> bool:
-        """Filter out loopback, unspecified ip"""
+    def is_valid_ip(ip: Optional[str]) -> bool:
+        """Filter out loopback, unspecified ip.
+
+        Accepts an optional value because callers pass raw payload fields
+        (asset_seen_ip is optional and may be missing or None). A None or
+        non-string value is treated as invalid: ipaddress.ip_address raises
+        ValueError for None/empty strings and TypeError for other types.
+        """
         try:
             ip_obj = ipaddress.ip_address(ip)
             return not (
                 ip_obj.is_loopback or ip_obj.is_unspecified or ip_obj.is_link_local
             )
-        except ValueError:
+        except (ValueError, TypeError):
             return False
 
     @staticmethod

--- a/injector_common/injector_common/targets.py
+++ b/injector_common/injector_common/targets.py
@@ -230,7 +230,12 @@ class Targets:
         """
         Extract target value from asset based on conditions:
         - Agentless + hostname => hostname
-        - Otherwise => first valid IP
+        - Otherwise => seen IP, else first valid local IP
+
+        The seen IP comes before the local ones because it is the address the platform
+        actually observed the endpoint at, and it is what the endpoint screen displays.
+        Going straight to the local IPs made the execution target an address the UI never
+        showed - an endpoint listed as 74.234.220.121 scanned at 192.168.56.11.
         """
         asset_id = asset.get("asset_id")
         agents = asset.get("asset_agents", [])
@@ -241,7 +246,12 @@ class Targets:
         if not agents and hostname:
             return hostname, asset_id
 
-        # Case 2: Agent present => try IPs
+        # Case 2: the address the platform saw this endpoint at
+        seen_ip = asset.get("asset_seen_ip")
+        if Targets.is_valid_ip(seen_ip):
+            return seen_ip, asset_id
+
+        # Case 3: no usable seen IP => fall back to the local ones
         for ip in asset_ips:
             if Targets.is_valid_ip(ip):
                 return ip, asset_id

--- a/injector_common/test/test_common_targets.py
+++ b/injector_common/test/test_common_targets.py
@@ -32,6 +32,20 @@ class CommonTargetsTest(TestCase):
             "asset_ips": [],  # no ips
             "asset_agents": True,
         }
+        self.asset_seen_and_local_ip = {
+            "asset_id": "a4",
+            "asset_hostname": None,
+            "asset_ips": ["192.168.56.11"],  # local address
+            "asset_seen_ip": "74.234.220.121",  # what the endpoint screen shows
+            "asset_agents": True,
+        }
+        self.asset_loopback_seen_ip = {
+            "asset_id": "a5",
+            "asset_hostname": None,
+            "asset_ips": ["10.0.0.5"],
+            "asset_seen_ip": "127.0.0.1",  # unusable, must fall back
+            "asset_agents": True,
+        }
 
         self.mock_helper = MagicMock()
 
@@ -50,6 +64,22 @@ class CommonTargetsTest(TestCase):
     def test_extract_property_target_value_no_valid_field(self):
         target = Targets.extract_property_target_value(self.empty_asset_ips)
         self.assertIsNone(target)
+
+    def test_extract_property_target_value_prefers_seen_ip_over_local_ip(self):
+        # The endpoint screen shows the seen IP, so automatic targeting must use it rather
+        # than a local address the operator never saw.
+        target, asset_id = Targets.extract_property_target_value(
+            self.asset_seen_and_local_ip
+        )
+        self.assertEqual(target, "74.234.220.121")
+        self.assertEqual(asset_id, "a4")
+
+    def test_extract_property_target_value_falls_back_when_seen_ip_unusable(self):
+        target, asset_id = Targets.extract_property_target_value(
+            self.asset_loopback_seen_ip
+        )
+        self.assertEqual(target, "10.0.0.5")
+        self.assertEqual(asset_id, "a5")
 
     # ---------- extract_targets ----------
 

--- a/injector_common/test/test_common_targets.py
+++ b/injector_common/test/test_common_targets.py
@@ -46,6 +46,13 @@ class CommonTargetsTest(TestCase):
             "asset_seen_ip": "127.0.0.1",  # unusable, must fall back
             "asset_agents": True,
         }
+        self.asset_none_seen_ip = {
+            "asset_id": "a6",
+            "asset_hostname": None,
+            "asset_ips": ["10.0.0.6"],
+            "asset_seen_ip": None,  # optional field, explicitly absent
+            "asset_agents": True,
+        }
 
         self.mock_helper = MagicMock()
 
@@ -80,6 +87,24 @@ class CommonTargetsTest(TestCase):
         )
         self.assertEqual(target, "10.0.0.5")
         self.assertEqual(asset_id, "a5")
+
+    def test_extract_property_target_value_falls_back_when_seen_ip_is_none(self):
+        # asset_seen_ip is optional and may be missing or None. That must not raise
+        # and must fall back to the first valid local IP.
+        target, asset_id = Targets.extract_property_target_value(
+            self.asset_none_seen_ip
+        )
+        self.assertEqual(target, "10.0.0.6")
+        self.assertEqual(asset_id, "a6")
+
+    def test_is_valid_ip_handles_none_and_invalid(self):
+        # Guards is_valid_ip against optional/None payload fields (asset_seen_ip)
+        # so automatic targeting never raises on assets without a seen IP.
+        self.assertFalse(Targets.is_valid_ip(None))
+        self.assertFalse(Targets.is_valid_ip(""))
+        self.assertFalse(Targets.is_valid_ip("not-an-ip"))
+        self.assertFalse(Targets.is_valid_ip("127.0.0.1"))
+        self.assertTrue(Targets.is_valid_ip("74.234.220.121"))
 
     # ---------- extract_targets ----------
 


### PR DESCRIPTION
Fixes #417 (reported as OpenAEV-Platform/filigran-private#257).

An endpoint was displayed at one address and scanned at another: the endpoint screen shows `winterfell` as `74.234.220.121` (its **seen IP**) while the nmap output showed the scan hitting `192.168.56.11`.

`automatic` is the default targeted-asset property across the injectors, and it never read `asset_seen_ip` - it fell straight through to the first entry of `asset_ips`, a local address. The field was available on the payload all along (the explicit `seen_ip` selector already reads it), so the platform was reporting one address and attacking another with nothing in the UI to reveal the difference.

### Change

In `extract_property_target_value`, try the seen IP before the local IPs:

1. agentless + hostname -> hostname *(unchanged)*
2. **seen IP, when valid** *(new)*
3. first valid local IP *(unchanged, now the fallback)*

`is_valid_ip` still filters loopback / unspecified / link-local, so an endpoint whose seen IP is unusable falls back exactly as before. The explicit `hostname` / `seen_ip` / `local_ip` selectors keep their precise meaning - only `automatic` changes.

### Follow-up hardening

`asset_seen_ip` is optional in payloads, so `extract_property_target_value` can call `is_valid_ip(None)` for assets without a seen IP. `is_valid_ip` now also catches `TypeError` (in addition to the `ValueError` that `ipaddress.ip_address` already raises for `None` / empty strings) and its type hint is widened to `Optional[str]`, making the optional-input contract explicit and defensive across input types. This addresses the Copilot review note on `is_valid_ip`.

### Verification

Tests added, run against the code **with and without** the original fix:

| test | without the fix |
|---|---|
| prefers the seen IP over the local IP | `AssertionError: '192.168.56.11' != '74.234.220.121'` - the reported IPs exactly |
| falls back when the seen IP is loopback | passes (guards the fallback against regression) |

Plus regression tests for the follow-up hardening: `automatic` falls back to the local IP when `asset_seen_ip` is `None`, and `is_valid_ip` returns `False` for `None` / empty / invalid values.

`18 passed` on the whole `injector_common` suite. `black`, `isort --profile black`, and `flake8` clean on the touched files.
